### PR TITLE
feat: add webauthn authentication

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
         <img src="Logobt.png" alt="BandTrack logo" class="logo-img">
     </header>
     <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@simplewebauthn/browser/dist/bundle/index.umd.min.js"></script>
     <script src="app.js"></script>
     <script>
       if ('serviceWorker' in navigator) {

--- a/server.js
+++ b/server.js
@@ -6,6 +6,16 @@ const crypto = require('crypto');
 const { promisify } = require('util');
 const pbkdf2 = promisify(crypto.pbkdf2);
 
+const ORIGIN = process.env.ORIGIN || 'http://localhost:3000';
+
+function base64urlToBuffer(str) {
+  return Buffer.from(str, 'base64url');
+}
+
+function bufferToBase64url(buf) {
+  return buf.toString('base64url');
+}
+
 // Import database helpers
 const db = require('./db');
 
@@ -56,6 +66,14 @@ function hasModRights(req) {
   return req.session.role === 'admin' || req.session.role === 'moderator';
 }
 
+// Middleware ensuring recent biometric verification
+function requireBiometric(req, res, next) {
+  if (!req.session.webauthn) {
+    return res.status(403).json({ error: 'Biometric verification required' });
+  }
+  next();
+}
+
 // ----------------- Authentication Routes -----------------
 
 // Register a new user
@@ -81,6 +99,7 @@ app.post('/api/register', async (req, res) => {
     req.session.userId = userId;
     req.session.username = username;
     req.session.role = role;
+    req.session.webauthn = false;
     res.json({ id: userId, username, role });
   } catch (err) {
     console.error(err);
@@ -107,6 +126,7 @@ app.post('/api/login', async (req, res) => {
     req.session.userId = user.id;
     req.session.username = user.username;
     req.session.role = user.role;
+    req.session.webauthn = false;
     res.json({ id: user.id, username: user.username, role: user.role });
   } catch (err) {
     console.error(err);
@@ -127,6 +147,79 @@ app.get('/api/me', (req, res) => {
     return res.status(401).json({ error: 'Not authenticated' });
   }
   res.json({ id: req.session.userId, username: req.session.username, role: req.session.role });
+});
+
+// ---------- WebAuthn Routes ----------
+
+// Generate registration challenge
+app.post('/api/webauthn/register', requireAuth, async (req, res) => {
+  const challenge = bufferToBase64url(crypto.randomBytes(32));
+  req.session.currentChallenge = challenge;
+  const userId = bufferToBase64url(Buffer.from(String(req.session.userId)));
+  const options = {
+    challenge,
+    rp: { name: 'BandTrack' },
+    user: { id: userId, name: req.session.username },
+    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+  };
+  res.json(options);
+});
+
+// Verify registration and store credential id
+app.post('/api/webauthn/verify-register', requireAuth, async (req, res) => {
+  try {
+    const expected = req.session.currentChallenge;
+    const clientData = JSON.parse(Buffer.from(req.body.response.clientDataJSON, 'base64url').toString());
+    if (clientData.challenge !== expected || clientData.type !== 'webauthn.create') {
+      return res.status(400).json({ error: 'Invalid challenge' });
+    }
+    await db.addWebAuthnCredential(req.session.userId, req.body.id);
+    req.session.webauthn = true;
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: 'Registration verification failed' });
+  }
+});
+
+// WebAuthn login / biometric verification
+app.post('/api/webauthn/login', async (req, res) => {
+  const { username } = req.body;
+  // Start authentication
+  if (username && !req.body.response) {
+    const user = await db.getUserByUsername(username);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    const creds = await db.getWebAuthnCredentials(user.id);
+    const challenge = bufferToBase64url(crypto.randomBytes(32));
+    req.session.currentChallenge = challenge;
+    req.session.authUserId = user.id;
+    const options = {
+      challenge,
+      allowCredentials: creds.map((c) => ({ id: c.credential_id, type: 'public-key' })),
+    };
+    return res.json(options);
+  }
+
+  // Verify authentication
+  try {
+    const expected = req.session.currentChallenge;
+    const clientData = JSON.parse(Buffer.from(req.body.response.clientDataJSON, 'base64url').toString());
+    if (clientData.challenge !== expected || clientData.type !== 'webauthn.get') {
+      return res.status(400).json({ error: 'Invalid challenge' });
+    }
+    const cred = await db.getWebAuthnCredentialById(req.body.id);
+    if (!cred) return res.status(400).json({ error: 'Unknown credential' });
+    const user = await db.getUserById(cred.user_id);
+    if (!user) return res.status(400).json({ error: 'User not found' });
+    req.session.userId = user.id;
+    req.session.username = user.username;
+    req.session.role = user.role;
+    req.session.webauthn = true;
+    res.json({ id: user.id, username: user.username, role: user.role });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: 'Authentication failed' });
+  }
 });
 
 // ----------------- Suggestion Routes -----------------
@@ -385,7 +478,7 @@ app.put('/api/performances/:id', requireAuth, async (req, res) => {
 });
 
 // Delete performance
-app.delete('/api/performances/:id', requireAuth, async (req, res) => {
+app.delete('/api/performances/:id', requireAuth, requireBiometric, async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid ID' });
   try {
@@ -446,7 +539,7 @@ app.get('/api/users', requireAuth, async (req, res) => {
   }
 });
 
-app.put('/api/users/:id', requireAuth, async (req, res) => {
+app.put('/api/users/:id', requireAuth, requireBiometric, async (req, res) => {
   if (req.session.role !== 'admin') {
     return res.status(403).json({ error: 'Forbidden' });
   }


### PR DESCRIPTION
## Summary
- add database table and helpers for storing WebAuthn credentials
- support WebAuthn registration and authentication APIs on the server
- require biometric verification for deleting performances and updating user roles
- integrate WebAuthn registration and login flows on the client

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689798d45e0c8327b98394e78e2b6ca6