### PR TITLE
Support author and location metadata

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -679,13 +679,13 @@
       e.preventDefault();
       const titleVal = inputTitle.value.trim();
       const authorVal = inputAuthor.value.trim();
-      const urlVal = inputYt.value.trim();
+      const youtubeVal = inputYt.value.trim();
       if (!titleVal) return;
       try {
         await api(`/suggestions/${item.id}`, 'PUT', {
           title: titleVal,
           author: authorVal,
-          url: urlVal,
+          youtube: youtubeVal,
         });
         if (modal.parentNode) {
           modal.parentNode.removeChild(modal); // or use modal.remove();
@@ -1198,6 +1198,11 @@
         const dateP = document.createElement('p');
         dateP.textContent = 'Date : ' + perf.date;
         details.appendChild(dateP);
+        if (perf.location) {
+          const locP = document.createElement('p');
+          locP.textContent = 'Lieu : ' + perf.location;
+          details.appendChild(locP);
+        }
         if (perf.songs && perf.songs.length > 0) {
           const ul = document.createElement('ul');
           perf.songs.forEach((id) => {
@@ -1278,6 +1283,12 @@
     inputDate.type = 'date';
     inputDate.required = true;
     inputDate.style.width = '100%';
+    // Lieu
+    const labelLoc = document.createElement('label');
+    labelLoc.textContent = 'Lieu';
+    const inputLoc = document.createElement('input');
+    inputLoc.type = 'text';
+    inputLoc.style.width = '100%';
     // Sélection des morceaux
     const labelSongs = document.createElement('label');
     labelSongs.textContent = 'Morceaux joués';
@@ -1296,6 +1307,8 @@
     form.appendChild(inputName);
     form.appendChild(labelDate);
     form.appendChild(inputDate);
+    form.appendChild(labelLoc);
+    form.appendChild(inputLoc);
     form.appendChild(labelSongs);
     form.appendChild(listDiv);
     content.appendChild(form);
@@ -1317,6 +1330,7 @@
       e.preventDefault();
       const name = inputName.value.trim();
       const dateVal = inputDate.value;
+      const locVal = inputLoc.value.trim();
       if (!name || !dateVal) return;
       const selected = [];
       listDiv.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
@@ -1341,7 +1355,7 @@
         return;
       }
       try {
-        await api('/performances', 'POST', { name, date: dateVal, songs: selected });
+        await api('/performances', 'POST', { name, date: dateVal, location: locVal, songs: selected });
         if (modal.parentNode) {
           modal.parentNode.removeChild(modal); // or use modal.remove();
         }
@@ -1388,6 +1402,13 @@
     inputDate.required = true;
     inputDate.style.width = '100%';
     inputDate.value = perf.date;
+    // Lieu
+    const labelLoc = document.createElement('label');
+    labelLoc.textContent = 'Lieu';
+    const inputLoc = document.createElement('input');
+    inputLoc.type = 'text';
+    inputLoc.style.width = '100%';
+    inputLoc.value = perf.location || '';
     // Morceaux
     const labelSongs = document.createElement('label');
     labelSongs.textContent = 'Morceaux joués';
@@ -1407,6 +1428,8 @@
     form.appendChild(inputName);
     form.appendChild(labelDate);
     form.appendChild(inputDate);
+    form.appendChild(labelLoc);
+    form.appendChild(inputLoc);
     form.appendChild(labelSongs);
     form.appendChild(listDiv);
     content.appendChild(form);
@@ -1428,6 +1451,7 @@
       e.preventDefault();
       const name = inputName.value.trim();
       const dateVal = inputDate.value;
+      const locVal = inputLoc.value.trim();
       if (!name || !dateVal) return;
       const selected = [];
       listDiv.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
@@ -1452,7 +1476,7 @@
         return;
       }
       try {
-        await api(`/performances/${perf.id}`, 'PUT', { name, date: dateVal, songs: selected });
+        await api(`/performances/${perf.id}`, 'PUT', { name, date: dateVal, location: locVal, songs: selected });
         if (modal.parentNode) {
           modal.parentNode.removeChild(modal); // or use modal.remove();
         }
@@ -1484,6 +1508,11 @@
     const dateP = document.createElement('p');
     dateP.textContent = 'Date : ' + perf.date;
     content.appendChild(dateP);
+    if (perf.location) {
+      const locP = document.createElement('p');
+      locP.textContent = 'Lieu : ' + perf.location;
+      content.appendChild(locP);
+    }
     // Liste des morceaux
     const ul = document.createElement('ul');
     if (perf.songs && perf.songs.length > 0) {

--- a/server.js
+++ b/server.js
@@ -237,12 +237,12 @@ app.get('/api/suggestions', requireAuth, async (req, res) => {
 
 // Create a new suggestion
 app.post('/api/suggestions', requireAuth, async (req, res) => {
-  const { title, url } = req.body;
+  const { title, author, youtube } = req.body;
   if (!title) {
     return res.status(400).json({ error: 'Title is required' });
   }
   try {
-    const newId = await db.createSuggestion(title, url || '', req.session.userId);
+    const newId = await db.createSuggestion(title, author || '', youtube || '', req.session.userId);
     const [created] = await Promise.all([
       db.getSuggestions().then((list) => list.find((s) => s.id === newId)),
     ]);
@@ -256,12 +256,12 @@ app.post('/api/suggestions', requireAuth, async (req, res) => {
 // Update an existing suggestion
 app.put('/api/suggestions/:id', requireAuth, async (req, res) => {
   const id = parseInt(req.params.id, 10);
-  const { title, url } = req.body;
+  const { title, author, youtube } = req.body;
   if (isNaN(id) || !title) {
     return res.status(400).json({ error: 'Invalid data' });
   }
   try {
-    const changes = await db.updateSuggestion(id, title, url || '', req.session.userId, req.session.role);
+    const changes = await db.updateSuggestion(id, title, author || '', youtube || '', req.session.userId, req.session.role);
     if (changes === 0) {
       return res.status(403).json({ error: 'Not permitted to update' });
     }
@@ -430,12 +430,12 @@ app.get('/api/performances', requireAuth, async (req, res) => {
 
 // Create a performance
 app.post('/api/performances', requireAuth, async (req, res) => {
-  const { name, date, songs } = req.body;
+  const { name, date, location, songs } = req.body;
   if (!name || !date) {
     return res.status(400).json({ error: 'Name and date are required' });
   }
   try {
-    const newId = await db.createPerformance(name, date, songs || [], req.session.userId);
+    const newId = await db.createPerformance(name, date, location || '', songs || [], req.session.userId);
     const list = await db.getPerformances();
     const created = list.find((p) => p.id === newId);
     res.status(201).json(created);
@@ -462,10 +462,10 @@ app.get('/api/performances/:id', requireAuth, async (req, res) => {
 // Update performance
 app.put('/api/performances/:id', requireAuth, async (req, res) => {
   const id = parseInt(req.params.id, 10);
-  const { name, date, songs } = req.body;
+  const { name, date, location, songs } = req.body;
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid ID' });
   try {
-    const changes = await db.updatePerformance(id, name, date, songs || [], req.session.userId, req.session.role);
+    const changes = await db.updatePerformance(id, name, date, location || '', songs || [], req.session.userId, req.session.role);
     if (changes === 0) {
       return res.status(403).json({ error: 'Not permitted to update' });
     }


### PR DESCRIPTION
## Summary
- store author and YouTube link for suggestions and expose them through the API
- track performance location in the database and REST routes
- allow entering and displaying these fields on the frontend

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ae08de20832796242957d30afd21