### PR TITLE
feat: add basic metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,15 @@ permettre l'installation de l'application et son fonctionnement hors ligne.
 
 Les serveurs Node.js et Python gèrent tous deux ces champs et mettent à jour
 automatiquement les anciennes bases de données au démarrage.
+
+### Métriques serveur
+
+Un middleware Express enregistre la latence de chaque requête et le nombre
+d'erreurs (codes ≥ 400). Ces données sont conservées en mémoire depuis la
+dernière réinitialisation.
+
+- `GET /api/metrics` *(administrateur)* – retourne `totalRequests`,
+  `averageLatency` (ms), `errorRate` et `lastReset`.
+- `DELETE /api/metrics` *(administrateur)* – remet à zéro tous les compteurs.
+
+Les métriques sont également réinitialisées lors du redémarrage du serveur.


### PR DESCRIPTION
## Summary
- track request latency and errors via Express middleware
- expose GET/DELETE /api/metrics for admins to view or reset metrics
- document metrics usage and reset instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b38b5b0083279b148b063b2abd9d