### PR TITLE
Add backup script and restore documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 package-lock.json
 .env
+
+backups/
+audios/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -74,3 +74,24 @@ dernière réinitialisation.
 - `DELETE /api/metrics` *(administrateur)* – remet à zéro tous les compteurs.
 
 Les métriques sont également réinitialisées lors du redémarrage du serveur.
+
+### Sauvegardes et restauration
+
+Un script `backup.sh` crée une copie de la base `bandtrack.db` et du dossier `audios/` dans `backups/DATE` où `DATE` est un horodatage `YYYYMMDD_HHMMSS`.
+Les `MAX_BACKUPS` dernières sauvegardes seulement sont conservées (7 par défaut).
+
+```bash
+./backup.sh            # créer une sauvegarde
+MAX_BACKUPS=10 ./backup.sh  # conserver 10 sauvegardes
+```
+
+Pour restaurer une sauvegarde :
+
+1. Arrêter le serveur.
+2. Copier les fichiers depuis le dossier voulu :
+   ```bash
+   cp backups/DATE/bandtrack.db .
+   rm -rf audios
+   cp -r backups/DATE/audios audios
+   ```
+3. Redémarrer le serveur.

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_ROOT="backups"
+DEST="$BACKUP_ROOT/$TIMESTAMP"
+
+mkdir -p "$DEST"
+
+cp bandtrack.db "$DEST/"
+
+if [ -d audios ]; then
+  cp -r audios "$DEST/"
+fi
+
+MAX_BACKUPS=${MAX_BACKUPS:-7}
+
+cd "$BACKUP_ROOT"
+ls -1dt */ 2>/dev/null | tail -n +$((MAX_BACKUPS+1)) | xargs -r rm -rf


### PR DESCRIPTION
## Summary
- add script to backup database and audio files with rotation
- document backup and restore procedure
- ignore backup, audio, and cache directories

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b72b6b2883278eb2dde7dbef67d1