### PR TITLE
Add theme color and apple-touch icon link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#222222">
     <title>BandTrack – Application de suivi musical</title>
     <!--
       Cette application est développée conformément au cahier des charges V1 BandTrack.
@@ -12,6 +13,7 @@
       gestion des prestations et paramètres utilisateurs (nom du groupe, mode sombre).
     -->
     <link rel="stylesheet" href="style.css">
+    <link rel="apple-touch-icon" href="Logobt-512.png">
     <link rel="manifest" href="manifest.json">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add meta theme-color to index.html head
- link apple-touch-icon for 512x512 icon in index.html

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898681e63888327a87f0cf18f05c2c1