### PR TITLE
Handle offline navigation in service worker

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Offline</title>
+    <style>
+      body { font-family: sans-serif; text-align: center; padding: 2rem; }
+    </style>
+  </head>
+  <body>
+    <h1>You are offline</h1>
+    <p>This application is unavailable without an internet connection.</p>
+  </body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -5,7 +5,8 @@ const ASSETS = [
   '/style.css',
   '/app.js',
   '/Logobt.png',
-  '/manifest.json'
+  '/manifest.json',
+  '/offline.html'
 ];
 self.addEventListener('install', event => {
   event.waitUntil(
@@ -21,7 +22,15 @@ self.addEventListener('activate', event => {
 });
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
   event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(resp => {
+      return resp || fetch(event.request).catch(() => caches.match('/offline.html'));
+    })
   );
 });


### PR DESCRIPTION
## Summary
- Serve cached `index.html` for navigation requests when offline
- Add offline fallback page and include it in service worker cache

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68986828a25c83278584a0d28e2bd613