### PR TITLE
feat: allow SSL cert configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ serveur Node.js via une API REST.
 Pour démarrer le serveur localement:
 ```bash
 npm install
-SSL_KEY=certs/server.key SSL_CERT=certs/server.crt npm start
+SSL_KEY=certs/key.pem SSL_CERT=certs/cert.pem npm start
 ```
 
 ### HTTPS
@@ -33,7 +33,7 @@ Pour le développement, un certificat auto-signé peut être créé avec :
 
 ```bash
 mkdir certs
-openssl req -x509 -newkey rsa:2048 -nodes -keyout certs/server.key -out certs/server.crt -days 365 -subj "/CN=localhost"
+openssl req -x509 -newkey rsa:2048 -nodes -keyout certs/key.pem -out certs/cert.pem -days 365 -subj "/CN=localhost"
 ```
 
 Les chemins vers la clé privée et le certificat sont fournis via les

--- a/server.js
+++ b/server.js
@@ -27,9 +27,15 @@ db.init();
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// In production the SSL certificate is provided via environment variables so
+// that deployments can supply paths to certificates issued by a real CA (e.g.
+// Let's Encrypt).  For local development we fall back to the self-signed
+// certificates located in `certs/`.
+const keyPath = process.env.SSL_KEY || path.join(__dirname, 'certs', 'key.pem');
+const certPath = process.env.SSL_CERT || path.join(__dirname, 'certs', 'cert.pem');
 const httpsOptions = {
-  key: fs.readFileSync(path.join(__dirname, 'certs', 'key.pem')),
-  cert: fs.readFileSync(path.join(__dirname, 'certs', 'cert.pem')),
+  key: fs.readFileSync(keyPath),
+  cert: fs.readFileSync(certPath),
 };
 
 // Middleware to parse JSON bodies


### PR DESCRIPTION
## Summary
- enable SSL certificate/key configuration via `SSL_KEY` and `SSL_CERT` env vars, defaulting to bundled dev certs
- document env variable usage and matching certificate filenames

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689868529eac8327af63eb0011adb312