### PR TITLE
Fix merge artifact in database initialization

### DIFF
--- a/db.js
+++ b/db.js
@@ -211,16 +211,6 @@ function init() {
   // Ensure a default group exists
   db.run('INSERT OR IGNORE INTO groups (id, name) VALUES (1, ?)', ['Groupe de musique']);
 
-    );`
-  );
-
-  db.run(
-      FOREIGN KEY (user_id) REFERENCES users(id),
-      FOREIGN KEY (group_id) REFERENCES groups(id)
-    );`
-  );
-
-
   // Logs: audit trail of key actions
   db.run(
     `CREATE TABLE IF NOT EXISTS logs (


### PR DESCRIPTION
## Summary
- clean up residual merge conflict lines around group tables in `db.js`
- ensure default group creation and logs table setup remain intact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987f16e3308327b2dacd5f19fff5a2