### PR TITLE
feat: switch to membership-based roles

### DIFF
--- a/db.js
+++ b/db.js
@@ -451,8 +451,11 @@ function getUsers() {
 function updateUserRole(id, role) {
   return new Promise((resolve, reject) => {
     db.run('UPDATE users SET role = ? WHERE id = ?', [role, id], function (err) {
-      if (err) reject(err);
-      else resolve(this.changes);
+      if (err) return reject(err);
+      db.run('UPDATE memberships SET role = ? WHERE user_id = ?', [role, id], function (err2) {
+        if (err2) reject(err2);
+        else resolve(this.changes);
+      });
     });
   });
 }

--- a/public/app.js
+++ b/public/app.js
@@ -27,10 +27,10 @@
   let webAuthnVerified = false;
 
   function hasModRights() {
-    return currentUser && (currentUser.role === 'admin' || currentUser.role === 'moderator');
+    return currentUser && (currentUser.membershipRole === 'admin' || currentUser.membershipRole === 'moderator');
   }
   function isAdmin() {
-    return currentUser && currentUser.role === 'admin';
+    return currentUser && currentUser.membershipRole === 'admin';
   }
 
   /**


### PR DESCRIPTION
## Summary
- derive permissions from group memberships via new `verifyGroupAccess`
- enforce membership roles on suggestions, rehearsals, performances and settings routes
- reflect membership roles on the frontend and when updating user roles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898836d6e2c8327a34ea8e5de4c251c