### PR TITLE
Add automatic multi-group migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ dernière réinitialisation.
 
 Les métriques sont également réinitialisées lors du redémarrage du serveur.
 
+### Migration vers la gestion multi‑groupe
+
+Les bases de données créées avant l'introduction des groupes ne possèdent pas
+les tables `groups` et `memberships`. Au démarrage, le serveur vérifie leur
+présence et lance automatiquement une migration le cas échéant :
+
+1. création d'un groupe par défaut (ID 1) ;
+2. ajout de tous les utilisateurs comme membres de ce groupe ;
+3. mise à jour des tables de contenu pour inclure un champ `group_id`.
+
+La migration peut également être exécutée manuellement :
+
+```bash
+node scripts/migrate_to_multigroup.js
+# ou
+python3 scripts/migrate_to_multigroup.py
+```
+
 ### Sauvegardes et restauration
 
 Un script `backup.sh` crée une copie de la base `bandtrack.db` et du dossier `audios/` dans `backups/DATE` où `DATE` est un horodatage `YYYYMMDD_HHMMSS`.

--- a/scripts/migrate_to_multigroup.js
+++ b/scripts/migrate_to_multigroup.js
@@ -1,0 +1,106 @@
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const crypto = require('crypto');
+
+const DB_PATH = path.join(__dirname, '..', 'bandtrack.db');
+
+function generateCode() {
+  return crypto.randomBytes(4).toString('base64url');
+}
+
+function addGroupId(db, table) {
+  db.run(`ALTER TABLE ${table} ADD COLUMN group_id INTEGER`, () => {
+    db.run(`UPDATE ${table} SET group_id = 1 WHERE group_id IS NULL`);
+  });
+}
+
+function migrate() {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(DB_PATH);
+    db.get(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='groups'",
+      (err, row) => {
+        if (err) {
+          db.close();
+          return reject(err);
+        }
+        if (row) {
+          db.close();
+          return resolve(false); // already migrated
+        }
+        db.serialize(() => {
+          db.run(
+            `CREATE TABLE groups (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL,
+              invitation_code TEXT NOT NULL UNIQUE,
+              description TEXT,
+              logo_url TEXT,
+              created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+              owner_id INTEGER NOT NULL
+            );`
+          );
+          db.run(
+            `CREATE TABLE memberships (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              user_id INTEGER NOT NULL,
+              group_id INTEGER NOT NULL,
+              role TEXT NOT NULL,
+              nickname TEXT,
+              joined_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+              active INTEGER NOT NULL DEFAULT 1,
+              UNIQUE(user_id, group_id)
+            );`
+          );
+          const code = generateCode();
+          db.run(
+            'INSERT INTO groups (id, name, invitation_code, owner_id) VALUES (1, ?, ?, 1)',
+            ['Groupe de musique', code]
+          );
+          ['suggestions', 'rehearsals', 'performances', 'settings'].forEach((t) =>
+            addGroupId(db, t)
+          );
+          db.all('SELECT id, role FROM users', (uErr, users) => {
+            if (uErr) {
+              db.close();
+              return reject(uErr);
+            }
+            const stmt = db.prepare(
+              'INSERT INTO memberships (user_id, group_id, role, active) VALUES (?, 1, ?, 1)'
+            );
+            users.forEach((u) => stmt.run(u.id, u.role || 'user'));
+            stmt.finalize((fErr) => {
+              if (fErr) {
+                db.close();
+                return reject(fErr);
+              }
+              db.run(
+                "INSERT OR IGNORE INTO settings (group_id, group_name, dark_mode) VALUES (1, 'Groupe de musique', 0)",
+                (sErr) => {
+                  db.close();
+                  if (sErr) return reject(sErr);
+                  resolve(true);
+                }
+              );
+            });
+          });
+        });
+      }
+    );
+  });
+}
+
+if (require.main === module) {
+  migrate()
+    .then((ran) => {
+      if (ran) {
+        console.log('Migration to multi-group completed.');
+      }
+    })
+    .catch((err) => {
+      console.error('Migration failed:', err);
+      process.exit(1);
+    });
+}
+
+module.exports = migrate;

--- a/scripts/migrate_to_multigroup.py
+++ b/scripts/migrate_to_multigroup.py
@@ -1,0 +1,72 @@
+import os
+import sqlite3
+import base64
+
+DB_PATH = os.path.join(os.path.dirname(__file__), '..', 'bandtrack.db')
+
+
+def generate_code() -> str:
+    return base64.urlsafe_b64encode(os.urandom(4)).decode('ascii').rstrip('=')
+
+
+def migrate() -> bool:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='groups'")
+    if cur.fetchone():
+        conn.close()
+        return False
+
+    cur.execute(
+        '''CREATE TABLE groups (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               name TEXT NOT NULL,
+               invitation_code TEXT NOT NULL UNIQUE,
+               description TEXT,
+               logo_url TEXT,
+               created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+               owner_id INTEGER NOT NULL
+           );'''
+    )
+    cur.execute(
+        '''CREATE TABLE memberships (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               user_id INTEGER NOT NULL,
+               group_id INTEGER NOT NULL,
+               role TEXT NOT NULL,
+               nickname TEXT,
+               joined_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+               active INTEGER NOT NULL DEFAULT 1,
+               UNIQUE(user_id, group_id)
+           );'''
+    )
+    code = generate_code()
+    cur.execute(
+        'INSERT INTO groups (id, name, invitation_code, owner_id) VALUES (1, ?, ?, 1)',
+        ('Groupe de musique', code),
+    )
+    for table in ['suggestions', 'rehearsals', 'performances', 'settings']:
+        try:
+            cur.execute(f'ALTER TABLE {table} ADD COLUMN group_id INTEGER')
+            cur.execute(f'UPDATE {table} SET group_id = 1 WHERE group_id IS NULL')
+        except sqlite3.OperationalError:
+            pass
+    cur.execute('SELECT id, role FROM users')
+    for uid, role in cur.fetchall():
+        cur.execute(
+            'INSERT INTO memberships (user_id, group_id, role, active) VALUES (?, 1, ?, 1)',
+            (uid, role or 'user'),
+        )
+    cur.execute(
+        "INSERT OR IGNORE INTO settings (group_id, group_name, dark_mode) VALUES (1, 'Groupe de musique', 0)"
+    )
+    conn.commit()
+    conn.close()
+    return True
+
+
+if __name__ == '__main__':
+    if migrate():
+        print('Migration to multi-group completed.')
+    else:
+        print('No migration necessary.')

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const SQLiteStore = require('connect-sqlite3')(session);
 const crypto = require('crypto');
 const { promisify } = require('util');
 const pbkdf2 = promisify(crypto.pbkdf2);
+const { execSync } = require('child_process');
 
 const ORIGIN = process.env.ORIGIN || 'https://localhost:3000';
 
@@ -16,6 +17,15 @@ function base64urlToBuffer(str) {
 
 function bufferToBase64url(buf) {
   return buf.toString('base64url');
+}
+
+// Run migration script if the groups table is missing
+try {
+  execSync(`node ${path.join(__dirname, 'scripts', 'migrate_to_multigroup.js')}`, {
+    stdio: 'inherit',
+  });
+} catch (err) {
+  console.error('Migration script failed:', err);
 }
 
 // Import database helpers

--- a/server.py
+++ b/server.py
@@ -74,6 +74,7 @@ import urllib.parse
 import mimetypes
 from http import HTTPStatus
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from scripts.migrate_to_multigroup import migrate as migrate_to_multigroup
 
 #############################
 # Database initialisation
@@ -2131,6 +2132,7 @@ class BandTrackHandler(BaseHTTPRequestHandler):
 #############################
 
 def run_server(host: str = '0.0.0.0', port: int = 3000):
+    migrate_to_multigroup()
     init_db()
     server = ThreadingHTTPServer((host, port), BandTrackHandler)
     print(f"BandTrack server running on http://{host}:{port} (Ctrl-C to stop)")


### PR DESCRIPTION
## Summary
- add Node and Python migration scripts for moving existing data to multi-group schema
- automatically run migration on server start when the `groups` table is missing
- document multi-group migration steps in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898967b3b8883279f74b34b1117ef1d