### PR TITLE
Include scripts package in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 # the Python backend only.  The SQLite database will be created at runtime.
 COPY server.py ./
 COPY public ./public
+COPY scripts ./scripts
 
 # Create a volume for persistent database storage
 VOLUME ["/data"]


### PR DESCRIPTION
## Summary
- Copy the `scripts` directory into the Docker image so server imports work.

## Testing
- `pytest`
- ❌ `docker build -t bandtrack:test .` *(missing: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68989c15323483278e66f8d8e3db728f