### PR TITLE
Handle 401 errors based on login status

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -70,10 +70,10 @@
       if (json && json.error === 'No membership') {
         throw new Error('No membership');
       }
-      // Session invalide : retour à l’authentification
+      const wasLoggedIn = currentUser !== null;
       currentUser = null;
-      renderApp();
-      throw new Error('Non authentifié');
+      if (wasLoggedIn) renderApp();
+      throw new Error(json?.error || 'Non authentifié');
     }
     if (!res.ok) {
       throw new Error((json && json.error) || 'Erreur API');


### PR DESCRIPTION
## Summary
- Avoid rerender on failed login by checking previous user state in api helper
- Preserve backend error message when unauthenticated and rerender only for expired sessions

## Testing
- `pytest -q`
- Verified api helper only triggers `renderApp` after session expiration

------
https://chatgpt.com/codex/tasks/task_e_6898bc4e04e48327ad405ee3765a99a6