### PR TITLE
Expose group name and profile button in header

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -92,6 +92,10 @@
       applyTheme(settings.darkMode);
       applyTemplate(settings.template || 'classic');
       document.title = `${settings.groupName} – BandTrack`;
+      const groupNameEl = document.getElementById('group-name');
+      if (groupNameEl) groupNameEl.textContent = settings.groupName;
+      const profileImg = document.querySelector('#profile-btn img');
+      if (profileImg) profileImg.src = currentUser?.avatarUrl || 'Logobt-512.png';
     } catch (err) {
       currentUser = null;
     }
@@ -482,6 +486,15 @@
    */
   function renderMain(app) {
     app.innerHTML = '';
+    const profileBtn = document.getElementById('profile-btn');
+    if (profileBtn) {
+      profileBtn.onclick = () => {
+        if (currentPage !== 'settings') {
+          currentPage = 'settings';
+          renderMain(app);
+        }
+      };
+    }
     const pageDiv = document.createElement('div');
     pageDiv.className = 'page';
     app.appendChild(pageDiv);
@@ -493,7 +506,6 @@
       { key: 'suggestions', label: 'Propositions' },
       { key: 'rehearsals', label: 'Répétitions' },
       { key: 'performances', label: 'Prestations' },
-      { key: 'settings', label: 'Paramètres' },
     ];
     navItems.forEach((item) => {
       const btn = document.createElement('button');
@@ -1952,6 +1964,8 @@
       try {
         await api('/settings', 'PUT', { groupName: inputName.value, darkMode: settings.darkMode });
         document.title = `${inputName.value} – BandTrack`;
+        const groupNameEl = document.getElementById('group-name');
+        if (groupNameEl) groupNameEl.textContent = inputName.value;
       } catch (err) {
         alert(err.message);
       }

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,8 @@
 <body>
     <header class="header">
         <img src="Logobt.png" alt="BandTrack logo" class="logo-img">
+        <span id="group-name"></span>
+        <button id="profile-btn"><img src="Logobt-512.png" alt="Avatar"></button>
     </header>
     <div id="app"></div>
     <script src="app.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -95,6 +95,7 @@ body, html {
   right: 0;
   height: 60px;
   display: flex;
+  justify-content: space-between;
   align-items: center;
   padding: 0 16px;
   background-color: var(--nav-bg);
@@ -104,6 +105,17 @@ body, html {
 
 .logo-img {
   height: 40px;
+}
+
+#group-name {
+  flex: 1;
+  text-align: center;
+}
+
+#profile-btn img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
 }
 
 /* Formulaires d'authentification */


### PR DESCRIPTION
## Summary
- show current group name and avatar button in header
- style header layout, group name, and avatar image
- load group name from settings, remove settings tab, and handle avatar navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ddecee3883278e7f626eb420e42f