### PR TITLE
Use dedicated avatar image

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -95,7 +95,7 @@
       const groupNameEl = document.getElementById('group-name');
       if (groupNameEl) groupNameEl.textContent = settings.groupName;
       const profileImg = document.querySelector('#profile-btn img');
-      if (profileImg) profileImg.src = currentUser?.avatarUrl || 'Logobt-512.png';
+      if (profileImg) profileImg.src = currentUser?.avatarUrl || 'avatar.png';
     } catch (err) {
       currentUser = null;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     <header class="header">
         <img src="Logobt.png" alt="BandTrack logo" class="logo-img">
         <span id="group-name"></span>
-        <button id="profile-btn"><img src="Logobt-512.png" alt="Avatar"></button>
+        <button id="profile-btn"><img src="avatar.png" alt="Avatar"></button>
     </header>
     <div id="app"></div>
     <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- show avatar button using `avatar.png`
- default profile image also falls back to `avatar.png`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898e46d9d048327a1deb9fd2d268a38