### PR TITLE
feat: decouple migration from server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ serveur Node.js via une API REST.
 Pour démarrer le serveur localement:
 ```bash
 npm install
+npm run migrate
 SSL_KEY=certs/key.pem SSL_CERT=certs/cert.pem npm start
 ```
 
@@ -94,20 +95,20 @@ Les métriques sont également réinitialisées lors du redémarrage du serveur.
 ### Migration vers la gestion multi‑groupe
 
 Les bases de données créées avant l'introduction des groupes ne possèdent pas
-les tables `groups` et `memberships`. Au démarrage, le serveur vérifie leur
-présence et lance automatiquement une migration le cas échéant :
-
-1. création d'un groupe par défaut (ID 1) ;
-2. ajout de tous les utilisateurs comme membres de ce groupe ;
-3. mise à jour des tables de contenu pour inclure un champ `group_id`.
-
-La migration peut également être exécutée manuellement :
+les tables `groups` et `memberships`. Avant de démarrer le serveur, exécutez la
+migration :
 
 ```bash
-node scripts/migrate_to_multigroup.js
+npm run migrate
 # ou
-python3 scripts/migrate_to_multigroup.py
+node scripts/migrate_to_multigroup.js
 ```
+
+Cette opération :
+
+1. crée un groupe par défaut (ID 1) ;
+2. ajoute tous les utilisateurs comme membres de ce groupe ;
+3. met à jour les tables de contenu pour inclure un champ `group_id`.
 
 ### Sauvegardes et restauration
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Server backend for BandTrack app",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "migrate": "node scripts/migrate_to_multigroup.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server.js
+++ b/server.js
@@ -7,16 +7,6 @@ const SQLiteStore = require('connect-sqlite3')(session);
 const crypto = require('crypto');
 const { promisify } = require('util');
 const pbkdf2 = promisify(crypto.pbkdf2);
-const { execSync } = require('child_process');
-
-// Run migration script if the groups table is missing
-try {
-  execSync(`node ${path.join(__dirname, 'scripts', 'migrate_to_multigroup.js')}`, {
-    stdio: 'inherit',
-  });
-} catch (err) {
-  console.error('Migration script failed:', err);
-}
 
 // Import database helpers
 const db = require('./db');


### PR DESCRIPTION
## Summary
- stop running database migrations inside server startup
- add `npm run migrate` script to run multi-group migration
- document running migrations before starting the server

## Testing
- `npm run migrate`
- `SSL_KEY=certs/key.pem SSL_CERT=certs/cert.pem node server.js` *(fails: SQLITE_ERROR: no such column: likes)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689901bdf7c48327a2aed94af86cf8a8