### PR TITLE
Display invitation code in group settings

### DIFF
--- a/db.js
+++ b/db.js
@@ -1275,7 +1275,9 @@ function getSettings() {
 function getSettingsForGroup(groupId) {
   return new Promise((resolve, reject) => {
     db.get(
-      'SELECT group_name, dark_mode, template, next_rehearsal_date, next_rehearsal_location FROM settings WHERE group_id = ?',
+      `SELECT s.group_name, s.dark_mode, s.template, s.next_rehearsal_date, s.next_rehearsal_location, g.invitation_code
+       FROM settings s JOIN groups g ON s.group_id = g.id
+       WHERE s.group_id = ?`,
       [groupId],
       (err, row) => {
         if (err) reject(err);
@@ -1287,6 +1289,7 @@ function getSettingsForGroup(groupId) {
             template: row.template || 'classic',
             nextRehearsalDate: row.next_rehearsal_date || '',
             nextRehearsalLocation: row.next_rehearsal_location || '',
+            invitationCode: row.invitation_code,
           });
         }
       }

--- a/public/app.js
+++ b/public/app.js
@@ -1989,6 +1989,33 @@
     };
     groupSection.appendChild(labelName);
     groupSection.appendChild(inputName);
+    if (isAdmin()) {
+      const inviteDiv = document.createElement('div');
+      inviteDiv.style.marginTop = '8px';
+      let invitationCode = settings.invitationCode;
+      const codeSpan = document.createElement('span');
+      codeSpan.textContent = `Code d'invitation : ${invitationCode}`;
+      inviteDiv.appendChild(codeSpan);
+      const copyBtn = document.createElement('button');
+      copyBtn.textContent = 'Copier';
+      copyBtn.style.marginLeft = '8px';
+      copyBtn.onclick = () => navigator.clipboard.writeText(invitationCode);
+      inviteDiv.appendChild(copyBtn);
+      const renewBtn = document.createElement('button');
+      renewBtn.textContent = 'Renouveler';
+      renewBtn.style.marginLeft = '8px';
+      renewBtn.onclick = async () => {
+        try {
+          const data = await api('/groups/renew-code', 'POST');
+          invitationCode = data.invitationCode;
+          codeSpan.textContent = `Code d'invitation : ${invitationCode}`;
+        } catch (err) {
+          alert(err.message);
+        }
+      };
+      inviteDiv.appendChild(renewBtn);
+      groupSection.appendChild(inviteDiv);
+    }
     // Mode sombre
     const modeDiv = document.createElement('div');
     modeDiv.style.marginTop = '20px';


### PR DESCRIPTION
## Summary
- Include invitation code in settings API
- Show and manage invitation code in settings for group admins

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689906039df083278421f2784172c9f9