### PR TITLE
Ensure role column exists before migration

### DIFF
--- a/scripts/migrate_to_multigroup.py
+++ b/scripts/migrate_to_multigroup.py
@@ -51,6 +51,10 @@ def migrate() -> bool:
             cur.execute(f'UPDATE {table} SET group_id = 1 WHERE group_id IS NULL')
         except sqlite3.OperationalError:
             pass
+    cur.execute('PRAGMA table_info(users)')
+    columns = cur.fetchall()
+    if not any(col[1] == 'role' for col in columns):
+        cur.execute("ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'")
     cur.execute('SELECT id, role FROM users')
     for uid, role in cur.fetchall():
         cur.execute(


### PR DESCRIPTION
## Summary
- Ensure migration scripts add a `role` column to `users` if missing before populating `memberships`
- Mirror role column check in both JavaScript and Python migration scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899b8ce60108327833dcc8228814013