### PR TITLE
docs: add Windows note for env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ npm install
 npm run migrate
 SSL_KEY=certs/key.pem SSL_CERT=certs/cert.pem npm start
 ```
+> **Remarque :** sous Windows, la syntaxe `VAR=valeur` n'est pas supportée dans l'invite de commandes. Utilisez plutôt :
+> ```bat
+> set SSL_KEY=certs/key.pem && set SSL_CERT=certs/cert.pem && npm start
+> ```
+> ou la commande multiplateforme :
+> ```bash
+> npx cross-env SSL_KEY=certs/key.pem SSL_CERT=certs/cert.pem npm start
+> ```
+
 
 ### HTTPS
 


### PR DESCRIPTION
## Summary
- document Windows-friendly ways to set `SSL_KEY`/`SSL_CERT`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6899ba8deec88327a6901c0128f3b140