### PR TITLE
Support performance locations with migration

### DIFF
--- a/scripts/migrate_performance_location.py
+++ b/scripts/migrate_performance_location.py
@@ -1,0 +1,28 @@
+import os
+import sqlite3
+
+DB_PATH = os.path.join(os.path.dirname(__file__), '..', 'bandtrack.db')
+
+
+def migrate() -> bool:
+    """Ensure the performances table has a location column.
+    Returns True if a migration was performed."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(performances)")
+    columns = [row[1] for row in cur.fetchall()]
+    if 'location' not in columns:
+        cur.execute('ALTER TABLE performances ADD COLUMN location TEXT')
+        cur.execute("UPDATE performances SET location = '' WHERE location IS NULL")
+        conn.commit()
+        conn.close()
+        return True
+    conn.close()
+    return False
+
+
+if __name__ == '__main__':
+    if migrate():
+        print('Added location column to performances.')
+    else:
+        print('No migration necessary.')


### PR DESCRIPTION
## Summary
- Include `location` field when creating the `performances` table and expose it through performance APIs
- Add migration to backfill the new `location` column in existing databases

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0db8d73c83279b9210005cf1b6db