### PR TITLE
Style settings sections for consistent spacing

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2327,6 +2327,8 @@
     container.appendChild(themeSection);
     const rehearsalSection = renderRehearsalSection(currentSettings);
     container.appendChild(rehearsalSection);
+    const logoutSection = document.createElement('div');
+    logoutSection.className = 'settings-section';
     const logoutBtn = document.createElement('button');
     logoutBtn.className = 'logout-btn';
     logoutBtn.textContent = 'Se déconnecter';
@@ -2339,7 +2341,8 @@
         alert(err.message);
       }
     };
-    container.appendChild(logoutBtn);
+    logoutSection.appendChild(logoutBtn);
+    container.appendChild(logoutSection);
     if (isAdmin()) {
       const adminSection = await renderAdminSection(container);
       container.appendChild(adminSection);

--- a/public/style.css
+++ b/public/style.css
@@ -413,6 +413,19 @@ textarea {
   box-shadow: 0 2px 4px rgba(0,0,0,0.3);
 }
 
+/* Section générique pour les paramètres */
+.settings-section {
+  margin-top: 20px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--card-bg);
+}
+
+.settings-section h3 {
+  margin-top: 0;
+}
+
 /* Bouton de déconnexion */
 .logout-btn {
   margin-top: 20px;


### PR DESCRIPTION
## Summary
- add `.settings-section` styles and heading reset
- wrap logout button in a `settings-section` for consistent layout

## Testing
- `npm test` (fails: Missing script)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a5b26ecb883278b8aa3237a6aa28f