### PR TITLE
Gracefully handle absent group in admin settings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -76,6 +76,9 @@
       }
       throw new Error('No membership');
     }
+    if (res.status === 404 && path === '/context' && method === 'GET') {
+      return null;
+    }
     if (!res.ok) {
       throw new Error((json && json.error) || 'Erreur API');
     }
@@ -2145,8 +2148,20 @@
     const h3 = document.createElement('h3');
     h3.textContent = 'Administration';
     section.appendChild(h3);
+    if (activeGroupId == null || currentUser?.needsGroup) {
+      const p = document.createElement('p');
+      p.textContent = 'Aucun groupe actif';
+      section.appendChild(p);
+      return section;
+    }
     try {
       const group = await api('/context');
+      if (!group) {
+        const p = document.createElement('p');
+        p.textContent = 'Aucun groupe actif';
+        section.appendChild(p);
+        return section;
+      }
       const members = await api(`/groups/${activeGroupId}/members`);
       const groupHeader = document.createElement('h4');
       groupHeader.textContent = 'Tableau de bord du groupe';


### PR DESCRIPTION
## Summary
- Avoid calling context and member APIs when no group is active
- Treat 404 from `/api/context` as normal and return `null`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b73491c048327b2cb7ad6bfcc1f34