### PR TITLE
Rename 'Répétition' menu to 'En cours'

### DIFF
--- a/bandtrack_ccf_v4.md
+++ b/bandtrack_ccf_v4.md
@@ -57,7 +57,7 @@ Le classement automatique selon les votes positifs aide à prioriser le travail 
 
 Un mécanisme de conversion permet de transformer directement une suggestion approuvée en morceau de répétition, conservant toutes les métadonnées associées et facilitant la transition vers le travail actif.
 
-### 4.2 Répétitions et suivi des progrès
+### 4.2 En cours et suivi des progrès
 Chaque morceau en répétition dispose d'une fiche complète incluant les informations de base et les outils de suivi personnalisé. Les utilisateurs évaluent leur maîtrise via un curseur gradué de 0 à 10, avec coloration visuelle facilitant la lecture rapide des niveaux.
 
 Les notes textuelles personnelles permettent de consigner des observations techniques, des difficultés rencontrées ou des points d'amélioration. Ces notes restent privées à chaque utilisateur tout en contribuant à un suivi précis des progrès.
@@ -76,7 +76,7 @@ Les prestations passées constituent un historique consultatif permettant de sui
 ## 5. Interface utilisateur et expérience
 
 ### 5.1 Navigation et ergonomie
-L'interface adopte une navigation par onglets fixes en bas d'écran, optimisée pour l'usage mobile tout en restant fonctionnelle sur ordinateur. Les sections principales (Suggestions, Répétitions, Prestations, Paramètres) restent accessibles en un clic depuis tout écran.
+L'interface adopte une navigation par onglets fixes en bas d'écran, optimisée pour l'usage mobile tout en restant fonctionnelle sur ordinateur. Les sections principales (Suggestions, En cours, Prestations, Paramètres) restent accessibles en un clic depuis tout écran.
 
 Les fenêtres modales centrées gèrent l'ajout et la modification de contenus, maintenant le contexte visuel tout en offrant suffisamment d'espace pour les formulaires détaillés.
 

--- a/public/app.js
+++ b/public/app.js
@@ -566,7 +566,7 @@
     const navItems = [
       { key: 'home', label: 'Accueil' },
       { key: 'suggestions', label: 'Propositions' },
-      { key: 'rehearsals', label: 'Répétitions' },
+      { key: 'rehearsals', label: 'En cours' },
       { key: 'performances', label: 'Prestations' },
     ];
     navItems.forEach((item) => {
@@ -2104,7 +2104,7 @@
     const section = document.createElement('div');
     section.className = 'settings-section';
     const h3 = document.createElement('h3');
-    h3.textContent = 'Répétition';
+    h3.textContent = 'En cours';
     section.appendChild(h3);
     const labelDate = document.createElement('label');
     labelDate.textContent = 'Prochaine répétition (date/heure)';


### PR DESCRIPTION
## Summary
- Rename navigation menu label from "Répétitions" to "En cours"
- Update related heading and documentation to reflect new menu name

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b929e5dd88327bcfa8100b851fb2e