### PR TITLE
feat: manage events from settings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2239,86 +2239,131 @@
     return section;
   }
 
-  function renderRehearsalSection() {
+  async function renderEventsSection(settingsContainer) {
     const section = document.createElement('div');
     section.className = 'settings-section';
     const h3 = document.createElement('h3');
-    h3.textContent = 'Répétitions à venir';
+    h3.textContent = 'Événements à venir';
     section.appendChild(h3);
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    const addRehearsalBtn = document.createElement('button');
+    addRehearsalBtn.className = 'btn-secondary';
+    addRehearsalBtn.textContent = 'Nouvelle répétition';
+    addRehearsalBtn.onclick = () => showAddRehearsalModal(settingsContainer, refreshList);
+    const addPerformanceBtn = document.createElement('button');
+    addPerformanceBtn.className = 'btn-secondary';
+    addPerformanceBtn.textContent = 'Nouvelle prestation';
+    addPerformanceBtn.onclick = async () => {
+      if (rehearsalsCache.length === 0) {
+        try {
+          rehearsalsCache = await apiPaginated('/rehearsals');
+        } catch (err) {
+          // ignore
+        }
+      }
+      showAddPerformanceModal(settingsContainer, refreshList);
+    };
+    actions.appendChild(addRehearsalBtn);
+    actions.appendChild(addPerformanceBtn);
+    section.appendChild(actions);
 
     const listDiv = document.createElement('div');
     section.appendChild(listDiv);
 
     async function refreshList() {
       listDiv.innerHTML = '';
+      let items = [];
       try {
-        const events = await api('/rehearsal-events');
-        if (events.length === 0) {
-          const p = document.createElement('p');
-          p.textContent = 'Aucune répétition planifiée';
-          listDiv.appendChild(p);
-        } else {
-          const ul = document.createElement('ul');
-          events.forEach((ev) => {
-            const li = document.createElement('li');
-            li.textContent = `${ev.date}${ev.location ? ' – ' + ev.location : ''}`;
-            const delBtn = document.createElement('button');
-            delBtn.textContent = 'Supprimer';
-            delBtn.style.marginLeft = '8px';
-            delBtn.onclick = async () => {
-              if (!confirm('Supprimer cette répétition ?')) return;
-              try {
-                await api(`/rehearsal-events/${ev.id}`, 'DELETE');
-                await refreshList();
-              } catch (err) {
-                alert(err.message);
-              }
-            };
-            li.appendChild(delBtn);
-            ul.appendChild(li);
-          });
-          listDiv.appendChild(ul);
-        }
+        const params = new URLSearchParams();
+        const now = new Date();
+        const start = now.toISOString().slice(0, 10);
+        const endDate = new Date(now);
+        endDate.setMonth(endDate.getMonth() + 6);
+        const end = endDate.toISOString().slice(0, 10);
+        params.set('start', start);
+        params.set('end', end);
+        items = await api(`/agenda?${params.toString()}`);
       } catch (err) {
         const p = document.createElement('p');
         p.style.color = 'var(--danger-color)';
-        p.textContent = 'Impossible de récupérer les répétitions';
+        p.textContent = "Impossible de récupérer l'agenda";
         listDiv.appendChild(p);
-      }
-    }
-
-    const formDiv = document.createElement('div');
-    formDiv.style.marginTop = '12px';
-    const dateInput = document.createElement('input');
-    dateInput.type = 'datetime-local';
-    const locInput = document.createElement('input');
-    locInput.type = 'text';
-    locInput.placeholder = 'Lieu';
-    locInput.style.marginLeft = '8px';
-    const addBtn = document.createElement('button');
-    addBtn.textContent = 'Ajouter';
-    addBtn.style.marginLeft = '8px';
-    addBtn.onclick = async () => {
-      if (!dateInput.value) {
-        alert('Date requise');
         return;
       }
-      try {
-        await api('/rehearsal-events', 'POST', {
-          date: dateInput.value,
-          location: locInput.value || '',
-        });
-        dateInput.value = '';
-        locInput.value = '';
-        await refreshList();
-      } catch (err) {
-        alert(err.message);
+      if (rehearsalsCache.length === 0) {
+        try {
+          rehearsalsCache = await apiPaginated('/rehearsals');
+        } catch (err) {
+          // ignore
+        }
       }
-    };
-    formDiv.appendChild(dateInput);
-    formDiv.appendChild(locInput);
-    formDiv.appendChild(addBtn);
-    section.appendChild(formDiv);
+      items.sort((a, b) => a.date.localeCompare(b.date));
+      if (items.length === 0) {
+        const p = document.createElement('p');
+        p.textContent = 'Aucun événement prévu';
+        listDiv.appendChild(p);
+        return;
+      }
+      const ul = document.createElement('ul');
+      items.forEach((item) => {
+        const li = document.createElement('li');
+        const label = item.title || item.location || '';
+        const typeLabel = item.type === 'performance' ? 'Prestation' : 'Répétition';
+        li.textContent = `${item.date} – ${label || typeLabel}`;
+        const actions = document.createElement('div');
+        actions.className = 'actions';
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn-secondary';
+        editBtn.textContent = 'Modifier';
+        editBtn.onclick = async () => {
+          if (item.type === 'performance') {
+            try {
+              const perf = await api(`/performances/${item.id}`);
+              showEditPerformanceModal(perf, settingsContainer, refreshList);
+            } catch (err) {
+              alert(err.message);
+            }
+          } else {
+            let song = rehearsalsCache.find((r) => r.id === item.id);
+            if (!song) {
+              try {
+                rehearsalsCache = await apiPaginated('/rehearsals');
+              } catch (err) {
+                // ignore
+              }
+              song = rehearsalsCache.find((r) => r.id === item.id);
+            }
+            if (song) {
+              showEditRehearsalModal(song, settingsContainer, refreshList);
+            }
+          }
+        };
+        actions.appendChild(editBtn);
+        const delBtn = document.createElement('button');
+        delBtn.className = 'btn-danger';
+        delBtn.textContent = 'Supprimer';
+        delBtn.onclick = async () => {
+          if (!confirm('Supprimer cet événement ?')) return;
+          try {
+            if (item.type === 'performance') {
+              await api(`/performances/${item.id}`, 'DELETE');
+            } else {
+              await api(`/rehearsals/${item.id}`, 'DELETE');
+              rehearsalsCache = rehearsalsCache.filter((r) => r.id !== item.id);
+            }
+            await refreshList();
+          } catch (err) {
+            alert(err.message);
+          }
+        };
+        actions.appendChild(delBtn);
+        li.appendChild(actions);
+        ul.appendChild(li);
+      });
+      listDiv.appendChild(ul);
+    }
 
     refreshList();
     return section;
@@ -2522,8 +2567,8 @@
     await refreshGroups();
     const themeSection = renderThemeSection(currentSettings);
     container.appendChild(themeSection);
-    const rehearsalSection = renderRehearsalSection();
-    container.appendChild(rehearsalSection);
+    const eventsSection = await renderEventsSection(container);
+    container.appendChild(eventsSection);
     const logoutSection = document.createElement('div');
     logoutSection.className = 'settings-section';
     const logoutBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- add upcoming events management section to settings
- allow creating, editing, and removing rehearsals and performances from settings

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c7ff15bd8832792c109ca18fdab5f