### PR TITLE
feat: add icon navigation and responsive menu

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -566,24 +566,30 @@
     const nav = document.createElement('div');
     nav.className = 'nav-bar';
     const navItems = [
-      { key: 'home', label: 'Accueil' },
-      { key: 'suggestions', label: 'Propositions' },
-      { key: 'rehearsals', label: 'En cours' },
-      { key: 'performances', label: 'Prestations' },
-      { key: 'agenda', label: 'Agenda' },
+      { key: 'home', label: 'Accueil', icon: 'fa-solid fa-house' },
+      { key: 'suggestions', label: 'Propositions', icon: 'fa-solid fa-lightbulb' },
+      { key: 'rehearsals', label: 'En cours', icon: 'fa-solid fa-clipboard-list' },
+      { key: 'performances', label: 'Prestations', icon: 'fa-solid fa-microphone' },
+      { key: 'agenda', label: 'Agenda', icon: 'fa-solid fa-calendar-days' },
     ];
     navItems.forEach((item) => {
       const btn = document.createElement('button');
-      btn.textContent = item.label;
       btn.className = currentPage === item.key ? 'active' : '';
+      btn.setAttribute('aria-label', item.label);
+      btn.innerHTML = `<i class="${item.icon}" aria-hidden="true"></i><span class="nav-label">${item.label}</span>`;
       btn.onclick = () => {
         if (currentPage !== item.key) {
           currentPage = item.key;
           renderMain(app);
         }
+        nav.classList.remove('open');
       };
       nav.appendChild(btn);
     });
+    const navToggle = document.getElementById('nav-toggle');
+    if (navToggle) {
+      navToggle.onclick = () => nav.classList.toggle('open');
+    }
     app.appendChild(nav);
     // Rendu de la page en fonction de currentPage
     if (currentPage === 'home') {

--- a/public/index.html
+++ b/public/index.html
@@ -13,11 +13,15 @@
       gestion des prestations et paramètres utilisateurs (nom du groupe, mode sombre).
     -->
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-16hmv5Nv2y5X2J1v4bS2+NYAQxNW2YydrZV+4WsrNG0Eyd4plBlKnbZnyBs+hpYBjQ6f6+g9cCuQ50T+Y1q3jw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="apple-touch-icon" href="Logobt-512.png">
     <link rel="manifest" href="manifest.json">
 </head>
 <body>
     <header class="header">
+        <button id="nav-toggle" class="hamburger" aria-label="Menu">
+            <i class="fa-solid fa-bars"></i>
+        </button>
         <img src="Logobt.png" alt="BandTrack logo" class="logo-img">
         <span id="group-name"></span>
         <div id="user-info">

--- a/public/style.css
+++ b/public/style.css
@@ -220,6 +220,7 @@ body, html {
   justify-content: space-around;
   background-color: var(--nav-bg);
   border-top: 1px solid var(--nav-border);
+  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
   z-index: 100;
 }
 
@@ -237,9 +238,39 @@ body, html {
   cursor: pointer;
 }
 
+.nav-bar button i {
+  font-size: 3vh;
+}
+
+.nav-bar button .nav-label {
+  font-size: 1.2vh;
+}
+
 .nav-bar button.active {
   color: var(--primary-color);
   font-weight: bold;
+}
+
+#nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 4vh;
+  color: var(--text-color);
+  cursor: pointer;
+}
+
+@media (max-width: 480px) {
+  .nav-bar {
+    transform: translateY(100%);
+    transition: transform 0.3s ease;
+  }
+  .nav-bar.open {
+    transform: translateY(0);
+  }
+  #nav-toggle {
+    display: block;
+  }
 }
 
 /* Contenu de page */


### PR DESCRIPTION
## Summary
- integrate Font Awesome and icon-based navigation with secondary labels
- add hamburger header button to toggle navigation on small screens
- animate nav visibility and improve contrast styling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cd4298cc0832787026f3293941c67