### PR TITLE
docs: document docker and ssl setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,39 @@ minimaliste via une API REST.
 - Écran d'accueil indiquant la prochaine prestation et la date de la prochaine
   répétition
 
-## Démarrage rapide avec Docker
+## Déploiement avec Docker
+
+### Générer des certificats SSL
+
+```bash
+mkdir -p certs
+openssl req -x509 -nodes -newkey rsa:2048 -keyout certs/key.pem -out certs/cert.pem -subj "/CN=localhost"
+```
+
+### Construire l'image
+
+```bash
+docker build -t bandtrack .
+```
+
+### Démarrer avec `docker run`
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$(pwd)/certs:/certs:ro" \
+  -e HOST=0.0.0.0 -e PORT=8080 \
+  -e SSL_KEY=/certs/key.pem -e SSL_CERT=/certs/cert.pem \
+  -e ORIGIN=https://localhost:8080 \
+  bandtrack
+```
+
+### Démarrer avec `docker compose`
 
 ```bash
 docker compose up --build
 ```
 
-L'image construit `server.py` et expose l'API sur le port `8080` par défaut.
-Les variables d'environnement `HOST` et `PORT` peuvent être ajustées dans
-`docker-compose.yml` ou passées à `docker run`.
+Les variables d'environnement peuvent aussi être définies dans `docker-compose.yml`.
 
 ### Exécution locale sans Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     container_name: bandtrack
     ports:
       - "8080:8080"
+    volumes:
+      - ./certs:/certs:ro
     environment:
       - HOST=0.0.0.0
       - PORT=8080
+      - SSL_KEY=/certs/key.pem
+      - SSL_CERT=/certs/cert.pem
+      - ORIGIN=https://localhost:8080
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Docker deployment guide with SSL certificate generation
- include environment variables for SSL and origin in Docker compose example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f79d0115c8327bce71032fa3c2d37