### PR TITLE
Make multigroup migration optional for new DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ docker compose up --build
 
 Les variables d'environnement peuvent aussi être définies dans `docker-compose.yml`.
 
+Lors du démarrage du conteneur, `server.py` exécute automatiquement les
+scripts de migration Python présents dans le dossier `scripts/`
+(`migrate_to_multigroup.py`, `migrate_performance_location.py`,
+`migrate_suggestion_votes.py`). Ils assurent la compatibilité des anciennes
+bases de données sans dépendance à Node.js.
+
 ### Exécution locale sans Docker
 
 ```bash

--- a/scripts/migrate_to_multigroup.py
+++ b/scripts/migrate_to_multigroup.py
@@ -12,6 +12,14 @@ def generate_code() -> str:
 def migrate() -> bool:
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()
+    # If the core "users" table does not exist yet we are dealing with a
+    # fresh database created by ``init_db`` and there is nothing to migrate.
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+    if not cur.fetchone():
+        conn.close()
+        return False
+    # Abort early when the migration has already been applied (``groups``
+    # table present).
     cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='groups'")
     if cur.fetchone():
         conn.close()


### PR DESCRIPTION
## Summary
- Avoid running multi-group migration when users table is missing
- Document Python migration scripts executed on container startup

## Testing
- `python -u server.py --port 9999 >/tmp/server.log 2>&1 & PID=$!; sleep 2; kill $PID; cat /tmp/server.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7aa7a8a483279123cf50c1d92a63