### PR TITLE
Clarify Python-only backend and document tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ python3 server.py --port 8080
 Le serveur utilise uniquement la bibliothèque standard de Python et crée la
 base SQLite `bandtrack.db` au premier lancement.
 
+## Tests
+
+Les tests automatisés ciblent uniquement la version Python et peuvent être exécutés dans le conteneur :
+
+```bash
+pytest
+```
+
+Aucun environnement Node.js n'est nécessaire.
+
 ## Réinitialiser la base de données
 
 ```bash

--- a/bandtrack_ccf_v4.md
+++ b/bandtrack_ccf_v4.md
@@ -19,7 +19,7 @@ La PWA permet une installation directe sur l'écran d'accueil des smartphones et
 ### 2.3 Backend et API
 Le backend Python fournit une API REST complète accessible via les endpoints `/api/*`. Toutes les opérations de création, lecture, mise à jour et suppression transitent par cette API, garantissant une cohérence des données et une sécurité homogène.
 
-L'architecture supporte deux implémentations backend distinctes : une version Python utilisant uniquement la bibliothèque standard, et une version Node.js avec Express pour les déploiements nécessitant un écosystème JavaScript. Les deux implémentations exposent des endpoints identiques et maintiennent une compatibilité totale au niveau API.
+L'architecture repose désormais sur une seule implémentation backend en Python utilisant uniquement la bibliothèque standard. L'ancienne expérimentation Node.js avec Express n'est plus maintenue. L'API REST exposée reste compatible avec les endpoints utilisés par le frontend.
 
 ### 2.4 Persistance et déploiement
 La base de données SQLite stocke l'ensemble des informations applicatives avec une structure optimisée pour les performances et la cohérence. Pour les déploiements nécessitant une montée en charge, une migration vers PostgreSQL ou MySQL reste possible sans modification du code applicatif grâce à une couche d'abstraction appropriée.

--- a/server.py
+++ b/server.py
@@ -20,8 +20,8 @@ Key features
   PBKDF2 with SHA‑256 for security.  Sessions are stored in a
   ``sessions`` table and identified via a randomly generated cookie.
 * Suggestions, rehearsals and performances are persisted in a SQLite
-  database (`bandtrack.db`) with the same structure as the earlier
-  Node/Express prototype.
+  database (`bandtrack.db`) with the same structure as an earlier
+  Node/Express prototype, which has since been retired.
 * A single settings row stores the group name and dark mode flag, which
   are applied at load time for all users.
 * The API endpoints mirror those used by the frontend so that the


### PR DESCRIPTION
## Summary
- Document that BandTrack now relies solely on the Python backend; remove obsolete Node.js references
- Explain the retired Node/Express prototype in server docs
- Add a README section on running tests with pytest, no Node.js needed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7bf010988327b1dc2501de6ec643