### PR TITLE
Use agenda endpoint for rehearsal on home page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -528,9 +528,10 @@
 
     let nextRehearsalText = 'Prochaine répétition : —';
     try {
-      const list = await api('/rehearsal-events');
+      const list = await api('/agenda');
+      const rehearsals = list.filter((item) => item.type === 'rehearsal');
       const now = new Date();
-      const upcoming = list.filter((r) => new Date(r.date) >= now);
+      const upcoming = rehearsals.filter((r) => new Date(r.date) >= now);
       upcoming.sort((a, b) => new Date(a.date) - new Date(b.date));
       if (upcoming.length > 0) {
         const r = upcoming[0];


### PR DESCRIPTION
## Summary
- Query `/agenda` instead of `/rehearsal-events` for next rehearsal on the home page
- Filter agenda items by rehearsal type before selecting the next upcoming rehearsal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8ae6b71c8327b3044a151c6573bb