### PR TITLE
Color-code calendar events by type

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1589,7 +1589,7 @@
         .filter((ev) => ev.date === dayStr)
         .forEach((ev) => {
           const evDiv = document.createElement('div');
-          evDiv.className = 'calendar-event';
+          evDiv.className = `calendar-event ${ev.type === 'performance' ? 'performance' : 'rehearsal'}`;
           const label = ev.title || ev.location || '';
           const typeLabel = ev.type === 'performance' ? 'Prestation' : 'Répétition';
           evDiv.textContent = label || typeLabel;

--- a/public/style.css
+++ b/public/style.css
@@ -499,3 +499,11 @@ textarea {
   cursor: pointer;
   font-size: 12px;
 }
+
+.calendar-event.performance {
+  background: #f66;
+}
+
+.calendar-event.rehearsal {
+  background: #6cf;
+}


### PR DESCRIPTION
## Summary
- Add conditional performance/rehearsal classes when rendering calendar events
- Style calendar events differently based on type

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8f7edb188327bf3c07d7b23eeb3a