### PR TITLE
fix: handle agenda event dates with time

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1585,7 +1585,7 @@
       cell.appendChild(dateLabel);
 
       const dayStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-      const eventsForDay = items.filter((ev) => ev.date === dayStr);
+      const eventsForDay = items.filter((ev) => ev.date?.startsWith(dayStr));
       eventsForDay.forEach((ev) => {
         const evDiv = document.createElement('div');
         evDiv.className = `calendar-event ${ev.type === 'performance' ? 'performance' : 'rehearsal'}`;


### PR DESCRIPTION
## Summary
- handle event dates containing a time in agenda filter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f959b9ab88327abd01af868cf4c2e