### PR TITLE
Remove next rehearsal fields from settings

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,9 +26,7 @@ def test_default_settings_creation(tmp_path):
         assert data == {
             'groupName': 'Band2',
             'darkMode': False,
-            'template': 'classic',
-            'nextRehearsalDate': '',
-            'nextRehearsalLocation': ''
+            'template': 'classic'
         }
 
         # delete settings row and ensure GET recreates defaults


### PR DESCRIPTION
## Summary
- remove `next_rehearsal_date` and `next_rehearsal_location` from settings schema and migrations
- simplify group creation and settings API to drop next rehearsal fields
- adjust tests for new settings payload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f995c4c9c832784fe3d53fafad292