### PR TITLE
Remove performances navigation entry

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -581,7 +581,6 @@
       { key: 'home', label: 'Accueil' },
       { key: 'suggestions', label: 'Propositions' },
       { key: 'rehearsals', label: 'En cours' },
-      { key: 'performances', label: 'Prestations' },
       { key: 'agenda', label: 'Agenda' },
     ];
     navItems.forEach((item) => {


### PR DESCRIPTION
## Summary
- drop 'Prestations' from navigation items to retain only four sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f9ee9b67083278c0f702126c43a79