### PR TITLE
Add profile dropdown menu for performances and settings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -34,6 +34,16 @@
     rehearsalsCache = [];
   }
 
+  // Ferme le menu profil lorsqu'on clique à l'extérieur
+  document.addEventListener('click', (e) => {
+    const menu = document.getElementById('profile-menu');
+    const btn = document.getElementById('profile-btn');
+    if (!menu || !btn) return;
+    if (menu.classList.contains('show') && !menu.contains(e.target) && e.target !== btn && !btn.contains(e.target)) {
+      menu.classList.remove('show');
+    }
+  });
+
   function hasModRights() {
     return currentUser && (currentUser.membershipRole === 'admin' || currentUser.membershipRole === 'moderator');
   }
@@ -563,12 +573,31 @@
   function renderMain(app) {
     app.innerHTML = '';
     const profileBtn = document.getElementById('profile-btn');
-    if (profileBtn) {
-      profileBtn.onclick = () => {
+    const profileMenu = document.getElementById('profile-menu');
+    const perfBtn = document.getElementById('menu-performances');
+    const settingsBtn = document.getElementById('menu-settings');
+    if (profileBtn && profileMenu) {
+      profileBtn.onclick = (e) => {
+        e.stopPropagation();
+        profileMenu.classList.toggle('show');
+      };
+    }
+    if (perfBtn) {
+      perfBtn.onclick = () => {
+        if (currentPage !== 'performances') {
+          currentPage = 'performances';
+          renderMain(app);
+        }
+        profileMenu?.classList.remove('show');
+      };
+    }
+    if (settingsBtn) {
+      settingsBtn.onclick = () => {
         if (currentPage !== 'settings') {
           currentPage = 'settings';
           renderMain(app);
         }
+        profileMenu?.classList.remove('show');
       };
     }
     const pageDiv = document.createElement('div');

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,10 @@
         <div id="user-info">
             <span id="user-name"></span>
             <button id="profile-btn"><img src="avatar.png" alt="Avatar"></button>
+            <div id="profile-menu">
+                <button id="menu-performances">Prestations</button>
+                <button id="menu-settings">Paramètres</button>
+            </div>
         </div>
     </header>
     <div id="app"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -116,6 +116,7 @@ body, html {
   display: flex;
   align-items: center;
   gap: 8px;
+  position: relative;
 }
 
 #user-name {
@@ -126,6 +127,35 @@ body, html {
   width: 40px;
   height: 40px;
   border-radius: 50%;
+}
+
+#profile-menu {
+  position: absolute;
+  top: 48px;
+  right: 0;
+  background-color: var(--nav-bg);
+  border: 1px solid var(--nav-border);
+  border-radius: 4px;
+  display: none;
+  flex-direction: column;
+  z-index: 300;
+}
+
+#profile-menu.show {
+  display: flex;
+}
+
+#profile-menu button {
+  background: none;
+  border: none;
+  padding: 8px 16px;
+  text-align: left;
+  color: var(--text-color);
+  cursor: pointer;
+}
+
+#profile-menu button:hover {
+  background-color: var(--border-color);
 }
 
 /* Formulaires d'authentification */


### PR DESCRIPTION
## Summary
- add hidden dropdown under avatar with Prestations and Paramètres options
- style profile menu and toggle visibility via `show` class
- toggle menu from avatar and wire menu items to navigate to performances or settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f9feda0c88327ba7b66021f1280ba