### PR TITLE
Format performance dates with locale

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1415,7 +1415,7 @@
         const details = document.createElement('div');
         details.className = 'card-details';
         const dateP = document.createElement('p');
-        dateP.textContent = 'Date : ' + perf.date;
+        dateP.textContent = 'Date : ' + new Date(perf.date).toLocaleString();
         details.appendChild(dateP);
         if (perf.location) {
           const locP = document.createElement('p');
@@ -1984,7 +1984,7 @@
     h3.textContent = perf.name;
     content.appendChild(h3);
     const dateP = document.createElement('p');
-    dateP.textContent = 'Date : ' + perf.date;
+    dateP.textContent = 'Date : ' + new Date(perf.date).toLocaleString();
     content.appendChild(dateP);
     if (perf.location) {
       const locP = document.createElement('p');


### PR DESCRIPTION
## Summary
- Format performance dates using `toLocaleString` when listing performances
- Apply same locale-aware formatting in performance detail view

## Testing
- `pytest`
- `node -e "['2024-05-05T12:34:56','2023-01-01T00:00:00','2025-12-31T23:59:00'].forEach(d=>console.log(new Date(d).toLocaleString()))"`


------
https://chatgpt.com/codex/tasks/task_e_689fa42b37688327a5a160b2b842b4e1