### PR TITLE
Support multiple audio notes per user

### DIFF
--- a/scripts/migrate_audio_notes_array.js
+++ b/scripts/migrate_audio_notes_array.js
@@ -1,0 +1,59 @@
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const DB_PATH = path.join(__dirname, '..', 'bandtrack.db');
+
+function migrate() {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(DB_PATH);
+    db.serialize(() => {
+      db.all('SELECT id, audio_notes_json FROM rehearsals', (err, rows) => {
+        if (err) {
+          db.close();
+          return reject(err);
+        }
+        let updated = 0;
+        const stmt = db.prepare('UPDATE rehearsals SET audio_notes_json = ? WHERE id = ?');
+        rows.forEach((row) => {
+          let notes;
+          try {
+            notes = JSON.parse(row.audio_notes_json || '{}');
+          } catch {
+            notes = {};
+          }
+          let changed = false;
+          for (const user of Object.keys(notes)) {
+            const val = notes[user];
+            if (Array.isArray(val)) continue;
+            notes[user] = val ? [{ title: '', data: val }] : [];
+            changed = true;
+          }
+          if (changed) {
+            stmt.run(JSON.stringify(notes), row.id);
+            updated++;
+          }
+        });
+        stmt.finalize((err2) => {
+          db.close();
+          if (err2) reject(err2);
+          else resolve(updated);
+        });
+      });
+    });
+  });
+}
+
+if (require.main === module) {
+  migrate()
+    .then((count) => {
+      if (count) {
+        console.log(`Migration completed: converted ${count} rows.`);
+      }
+    })
+    .catch((err) => {
+      console.error('Migration failed:', err);
+      process.exit(1);
+    });
+}
+
+module.exports = migrate;

--- a/scripts/migrate_audio_notes_array.py
+++ b/scripts/migrate_audio_notes_array.py
@@ -1,0 +1,36 @@
+import os
+import json
+import sqlite3
+
+DB_PATH = os.path.join(os.path.dirname(__file__), '..', 'bandtrack.db')
+
+
+def migrate():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('SELECT id, audio_notes_json FROM rehearsals')
+    rows = cur.fetchall()
+    updated = 0
+    for rid, json_data in rows:
+        try:
+            notes = json.loads(json_data or '{}')
+        except Exception:
+            notes = {}
+        changed = False
+        for user, val in list(notes.items()):
+            if isinstance(val, list):
+                continue
+            notes[user] = [{'title': '', 'data': val}] if val else []
+            changed = True
+        if changed:
+            cur.execute('UPDATE rehearsals SET audio_notes_json = ? WHERE id = ?', (json.dumps(notes), rid))
+            updated += 1
+    conn.commit()
+    conn.close()
+    return updated
+
+
+if __name__ == '__main__':
+    count = migrate()
+    if count:
+        print(f'Migration completed: converted {count} rows.')

--- a/server.js
+++ b/server.js
@@ -518,7 +518,7 @@ app.post('/api/rehearsals', requireAuth, async (req, res) => {
 // Update the current user's level/notes/audio for a rehearsal
 app.put('/api/rehearsals/:id', requireAuth, async (req, res) => {
   const id = parseInt(req.params.id, 10);
-  const { level, note, audio, title, author, youtube, spotify } = req.body;
+  const { level, note, audio, audioTitle, title, author, youtube, spotify } = req.body;
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid ID' });
   const role = await verifyGroupAccess(req);
   if (!role) return res.status(403).json({ error: 'Forbidden' });
@@ -530,7 +530,7 @@ app.put('/api/rehearsals/:id', requireAuth, async (req, res) => {
         return res.status(403).json({ error: 'Not allowed to edit rehearsal details' });
       }
     } else {
-      await db.updateRehearsalUserData(id, req.session.username, level, note, audio);
+      await db.updateRehearsalUserData(id, req.session.username, level, note, audio, audioTitle);
     }
     const updated = await db.getRehearsalById(id, req.session.groupId);
     await db.logEvent(req.session.userId, 'edit', { entity: 'rehearsal', id });

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -147,6 +147,30 @@ def test_rehearsals_crud(tmp_path):
         status, _, _ = request("PUT", port, f"/api/1/rehearsals/{reh_id}", {"level": 5, "note": "ok"}, headers)
         assert status == 200
 
+        status, _, _ = request(
+            "PUT",
+            port,
+            f"/api/1/rehearsals/{reh_id}",
+            {"audio": "a1", "audioTitle": "t1"},
+            headers,
+        )
+        assert status == 200
+
+        status, _, _ = request(
+            "PUT",
+            port,
+            f"/api/1/rehearsals/{reh_id}",
+            {"audio": "a2", "audioTitle": "t2"},
+            headers,
+        )
+        assert status == 200
+
+        status, _, body = request("GET", port, "/api/1/rehearsals", headers=headers)
+        rehearsals = json.loads(body)
+        notes = rehearsals[0]["audioNotes"]["carol"]
+        assert len(notes) == 2
+        assert [n["title"] for n in notes] == ["t1", "t2"]
+
         status, _, body = request("PUT", port, f"/api/1/rehearsals/{reh_id}/mastered", headers=headers)
         assert status == 200
         assert json.loads(body)["mastered"] is True


### PR DESCRIPTION
## Summary
- Store rehearsal audio notes as arrays of {title, data} per user
- Allow adding titled audio clips without overwriting existing ones
- Provide migration and tests for multi-note audio storage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a191823a4c8327a28a172b5ea16080