### PR TITLE
Refine calendar event colors for better readability

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -535,9 +535,10 @@ textarea {
 }
 
 .calendar-event.performance {
-  background: #f66;
+  background: #b76ef5;
+  color: #000;
 }
 
 .calendar-event.rehearsal {
-  background: #6cf;
+  background: #7a42c4;
 }


### PR DESCRIPTION
## Summary
- update performance calendar event to use purple background and dark text
- adjust rehearsal event background color to complementary purple

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1b3d9e0488327b800ca476a834377