### PR TITLE
feat: update theme color to purple

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="BandTrack – application de suivi musical pour groupes" />
   <!-- PWA manifest and theme colour -->
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#1f102d" />
+  <meta name="theme-color" content="#9b59b6" />
   <!-- Main stylesheet -->
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "BandTrack",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#1f102d",
-  "theme_color": "#1f102d",
+  "background_color": "#9b59b6",
+  "theme_color": "#9b59b6",
   "icons": [
     {
       "src": "avatar.png",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,7 +1,7 @@
 // Service worker for BandTrack PWA
 // Cache assets for offline use and provide a fallback page when offline.
 
-const CACHE_NAME = 'bandtrack-cache-v2';
+const CACHE_NAME = 'bandtrack-cache-v3';
 const ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
- switch PWA theme color to purple in index and manifest
- bump service worker cache to refresh stored assets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1b57c3c088327adb81c361d29cf6a