### PR TITLE
Force dark mode by default

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -142,9 +142,10 @@
       const profileImg = document.querySelector('#profile-btn img');
       if (profileImg) profileImg.src = currentUser?.avatarUrl || 'avatar.png';
       if (!user.needsGroup) {
-        // Récupère les paramètres (notamment le mode sombre) pour appliquer le thème
+        // Récupère les paramètres pour appliquer le thème et le modèle
         const settings = await api('/settings');
-        applyTheme(settings.darkMode);
+        // Force le mode sombre par défaut
+        applyTheme(true);
         applyTemplate(settings.template || 'classic');
         document.title = `${settings.groupName} – BandTrack`;
         const groupNameEl = document.getElementById('group-name');


### PR DESCRIPTION
## Summary
- Force the web app to apply dark theme by default during session check

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1b690d50c8327813a8b755336f9f8