### PR TITLE
Integrate Tailwind CDN with pastel theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,25 @@
       authentification, suggestions de morceaux, suivi des répétitions,
       gestion des prestations et paramètres utilisateurs (nom du groupe, mode sombre).
     -->
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              pastel: {
+                50: '#fdf2f8'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <link rel="apple-touch-icon" href="Logobt-512.png">
     <link rel="manifest" href="manifest.json">
 </head>
-<body class="dark">
+<body class="font-sans bg-pastel-50 text-slate-800">
     <header class="header">
         <img src="Logobt.png" alt="BandTrack logo" class="logo-img">
         <span id="group-name"></span>

--- a/public/style.css
+++ b/public/style.css
@@ -73,7 +73,6 @@ body, html {
   margin: 0;
   padding: 0;
   height: 100%;
-  font-family: Arial, Helvetica, sans-serif;
   background-color: var(--bg-color);
   color: var(--text-color);
 }


### PR DESCRIPTION
## Summary
- add Tailwind CDN and pastel color palette to public page
- apply Tailwind classes and remove legacy font-family

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a21b0f88a0832789e66ca276775e09