### PR TITLE
Move profile menu and show active user in settings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -37,13 +37,11 @@
   // Ferme le menu lorsqu'on clique à l'extérieur
   document.addEventListener('click', (e) => {
     const menu = document.getElementById('profile-menu');
-    const profileBtn = document.getElementById('profile-btn');
     const hamburger = document.getElementById('hamburger');
     if (!menu) return;
     if (
       !menu.classList.contains('hidden') &&
       !menu.contains(e.target) &&
-      e.target !== profileBtn && !profileBtn?.contains(e.target) &&
       e.target !== hamburger && !hamburger?.contains(e.target)
     ) {
       menu.classList.add('hidden');
@@ -163,10 +161,6 @@
     try {
       const user = await api('/me');
       currentUser = user;
-      const userNameEl = document.getElementById('user-name');
-      if (userNameEl) userNameEl.textContent = currentUser.username;
-      const profileImg = document.querySelector('#profile-btn img');
-      if (profileImg) profileImg.src = currentUser?.avatarUrl || 'avatar.png';
       if (!user.needsGroup) {
         // Récupère les paramètres (notamment le mode sombre) pour appliquer le thème
         const settings = await api('/settings');
@@ -178,10 +172,6 @@
       }
     } catch (err) {
       currentUser = null;
-      const userNameEl = document.getElementById('user-name');
-      if (userNameEl) userNameEl.textContent = '';
-      const profileImg = document.querySelector('#profile-btn img');
-      if (profileImg) profileImg.src = 'avatar.png';
     }
   }
 
@@ -380,10 +370,6 @@
   function renderApp() {
     const app = document.getElementById('app');
     if (!currentUser) {
-      const userNameEl = document.getElementById('user-name');
-      if (userNameEl) userNameEl.textContent = '';
-      const profileImg = document.querySelector('#profile-btn img');
-      if (profileImg) profileImg.src = 'avatar.png';
       const groupNameEl = document.getElementById('group-name');
       if (groupNameEl) groupNameEl.textContent = '';
       resetCaches();
@@ -606,17 +592,10 @@
    */
   function renderMain(app) {
     app.innerHTML = '';
-    const profileBtn = document.getElementById('profile-btn');
     const hamburgerBtn = document.getElementById('hamburger');
     const profileMenu = document.getElementById('profile-menu');
     const perfBtn = document.getElementById('menu-performances');
     const settingsBtn = document.getElementById('menu-settings');
-    if (profileBtn && profileMenu) {
-      profileBtn.onclick = (e) => {
-        e.stopPropagation();
-        toggleMenu();
-      };
-    }
     if (hamburgerBtn && profileMenu) {
       hamburgerBtn.onclick = (e) => {
         e.stopPropagation();
@@ -2782,6 +2761,11 @@
     const header = document.createElement('h2');
     header.textContent = 'Paramètres';
     container.appendChild(header);
+    if (currentUser) {
+      const info = document.createElement('p');
+      info.textContent = `Utilisateur connecté: ${currentUser.username}`;
+      container.appendChild(info);
+    }
     let settings;
     try {
       settings = await api('/settings');

--- a/public/index.html
+++ b/public/index.html
@@ -32,16 +32,14 @@
 </head>
 <body class="font-sans bg-pastel-50 text-slate-800">
     <header class="header fixed top-0 w-full bg-pastel-50 transition-transform">
-        <button id="hamburger" class="flex flex-col justify-center items-center w-8 h-8 mr-2">
-            <span class="block w-6 h-0.5 bg-slate-800 mb-1 transition-transform"></span>
-            <span class="block w-6 h-0.5 bg-slate-800 mb-1 transition-transform"></span>
-            <span class="block w-6 h-0.5 bg-slate-800 transition-transform"></span>
-        </button>
         <img src="Logobt.png" alt="BandTrack logo" class="logo-img">
         <span id="group-name"></span>
-        <div id="user-info">
-            <span id="user-name"></span>
-            <button id="profile-btn"><img src="avatar.png" alt="Avatar"></button>
+        <div id="menu-container">
+            <button id="hamburger" class="flex flex-col justify-center items-center w-8 h-8">
+                <span class="block w-6 h-0.5 bg-slate-800 mb-1 transition-transform"></span>
+                <span class="block w-6 h-0.5 bg-slate-800 mb-1 transition-transform"></span>
+                <span class="block w-6 h-0.5 bg-slate-800 transition-transform"></span>
+            </button>
             <div id="profile-menu" class="hidden flex flex-col">
                 <button id="menu-performances">Prestations</button>
                 <button id="menu-settings">Paramètres</button>

--- a/public/style.css
+++ b/public/style.css
@@ -111,21 +111,10 @@ body, html {
   text-align: center;
 }
 
-#user-info {
+#menu-container {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 8px;
-  position: relative;
-}
-
-#user-name {
-  font-weight: bold;
-}
-
-#profile-btn img {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
 }
 
 #profile-menu {


### PR DESCRIPTION
## Summary
- Remove avatar and username from header and relocate hamburger menu to the right with links to Prestations and Paramètres
- Display the currently connected user at the top of the settings page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a229c8a32c83279ff2319b227b40d4