### PR TITLE
Simplify suggestion and rehearsal API calls

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -135,22 +135,6 @@
     return json;
   }
 
-  /**
-   * Récupère toutes les pages d'un point d'API paginé.
-   * @param {string} path Chemin de base (ex: '/suggestions')
-   * @param {number} limit Nombre d'éléments par page
-   */
-  async function apiPaginated(path, limit = 50) {
-    let offset = 0;
-    let all = [];
-    while (true) {
-      const page = await api(`${path}?limit=${limit}&offset=${offset}`);
-      all = all.concat(page);
-      if (!Array.isArray(page) || page.length < limit) break;
-      offset += limit;
-    }
-    return all;
-  }
 
   /**
    * Vérifie si un utilisateur est connecté en appelant `/api/me`.  Si c’est le
@@ -674,7 +658,7 @@
     container.appendChild(header);
     let list = [];
     try {
-      list = await apiPaginated('/suggestions');
+      list = await api('/suggestions');
     } catch (err) {
       const p = document.createElement('p');
       p.style.color = 'var(--danger-color)';
@@ -777,7 +761,7 @@
           e.stopPropagation();
           try {
             await api(`/suggestions/${item.id}/to-rehearsal`, 'POST');
-            rehearsalsCache = await apiPaginated('/rehearsals');
+            rehearsalsCache = await api('/rehearsals');
             renderSuggestions(container);
           } catch (err) {
             alert(err.message);
@@ -985,7 +969,7 @@
     container.appendChild(header);
     let list = [];
     try {
-      list = await apiPaginated('/rehearsals');
+      list = await api('/rehearsals');
       // Mettez en cache pour d’autres pages (prestations)
       rehearsalsCache = list;
     } catch (err) {
@@ -1231,7 +1215,7 @@
             // Rafraîchir la liste des répétitions et des prestations
             renderRehearsals(container);
             // Mettre à jour le cache des répétitions
-            rehearsalsCache = await apiPaginated('/rehearsals');
+            rehearsalsCache = await api('/rehearsals');
           } catch (err) {
             alert(err.message);
           }
@@ -1325,7 +1309,7 @@
           modal.parentNode.removeChild(modal); // or use modal.remove();
         }
         try {
-          rehearsalsCache = await apiPaginated('/rehearsals');
+          rehearsalsCache = await api('/rehearsals');
         } catch (err) {
           // ignore
         }
@@ -1428,7 +1412,7 @@
           modal.parentNode.removeChild(modal); // or use modal.remove();
         }
         // Mettre à jour le cache
-        rehearsalsCache = await apiPaginated('/rehearsals');
+        rehearsalsCache = await api('/rehearsals');
         if (typeof afterSave === 'function') afterSave();
         else {
           // Actualiser la page des répétitions
@@ -1470,7 +1454,7 @@
     // Assurer d’avoir les répétitions en cache pour afficher les titres
     if (rehearsalsCache.length === 0) {
       try {
-        rehearsalsCache = await apiPaginated('/rehearsals');
+        rehearsalsCache = await api('/rehearsals');
       } catch (err) {
         // ignore
       }
@@ -1677,7 +1661,7 @@
           if (ev.type === 'performance') {
             try {
               if (rehearsalsCache.length === 0) {
-                rehearsalsCache = await apiPaginated('/rehearsals');
+                rehearsalsCache = await api('/rehearsals');
               }
               const perfs = await api('/performances');
               const perf = perfs.find((p) => p.id === ev.id);
@@ -1701,7 +1685,7 @@
           if (isPerf) {
             try {
               if (rehearsalsCache.length === 0) {
-                rehearsalsCache = await apiPaginated('/rehearsals');
+                rehearsalsCache = await api('/rehearsals');
               }
             } catch (err) {
               // ignore cache errors


### PR DESCRIPTION
## Summary
- replace `apiPaginated` usage with direct `api` requests for suggestions and rehearsals
- drop unused `apiPaginated` helper

## Testing
- `pytest`
- ⚠️ `npm install jsdom` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a22d2537d08327bf52a7c2c86fbc8b