### PR TITLE
Improve homepage layout and menu emphasis

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -534,7 +534,7 @@
     container.className = 'home-container';
     app.appendChild(container);
 
-    let nextPerfText = 'Aucune prestation prévue';
+    let nextPerfInfo = 'Aucune prestation prévue';
     try {
       const list = await api('/performances');
       const now = new Date();
@@ -542,16 +542,16 @@
       upcoming.sort((a, b) => new Date(a.date) - new Date(b.date));
       if (upcoming.length > 0) {
         const p = upcoming[0];
-        nextPerfText = `Prochaine prestation : ${p.name} (${formatDateTime(p.date)})`;
+        nextPerfInfo = `${p.name} (${formatDateTime(p.date)})`;
       }
     } catch (err) {
-      nextPerfText = 'Impossible de récupérer les prestations';
+      nextPerfInfo = 'Impossible de récupérer les prestations';
     }
     const perfP = document.createElement('p');
-    perfP.textContent = nextPerfText;
+    perfP.innerHTML = `<strong>Prochaine prestation :</strong> ${nextPerfInfo}`;
     container.appendChild(perfP);
 
-    let nextRehearsalText = 'Prochaine répétition : —';
+    let nextRehearsalInfo = '—';
     try {
       const list = await api('/agenda');
       const rehearsals = list.filter((item) => item.type === 'rehearsal');
@@ -560,13 +560,13 @@
       upcoming.sort((a, b) => new Date(a.date) - new Date(b.date));
       if (upcoming.length > 0) {
         const r = upcoming[0];
-        nextRehearsalText = `Prochaine répétition : ${formatDateTime(r.date)}${r.location ? ' – ' + r.location : ''}`;
+        nextRehearsalInfo = `${formatDateTime(r.date)}${r.location ? ' – ' + r.location : ''}`;
       }
     } catch (err) {
       // ignore errors
     }
     const rehP = document.createElement('p');
-    rehP.textContent = nextRehearsalText;
+    rehP.innerHTML = `<strong>Prochaine répétition :</strong> ${nextRehearsalInfo}`;
     container.appendChild(rehP);
 
   }

--- a/public/style.css
+++ b/public/style.css
@@ -134,6 +134,7 @@ body, html {
   text-align: left;
   color: var(--text-color);
   cursor: pointer;
+  font-weight: bold;
 }
 
 #profile-menu button:hover {
@@ -198,16 +199,16 @@ body, html {
 }
 
 /* Page d'accueil après connexion */
-.home-container {
-  max-width: 400px;
-  margin: 60px auto;
-  padding: 20px;
-  background: var(--card-bg);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  text-align: center;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
+  .home-container {
+    max-width: 400px;
+    margin: 60px auto;
+    padding: 20px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    text-align: left;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
 
 .home-container button {
   padding: 10px 20px;
@@ -247,11 +248,11 @@ body, html {
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  font-weight: bold;
 }
 
 .nav-bar button.active {
   color: var(--primary-color);
-  font-weight: bold;
 }
 
 /* Contenu de page */
@@ -272,6 +273,7 @@ body, html {
 .card h3 {
   margin-top: 0;
   cursor: pointer;
+  font-weight: bold;
 }
 
 .card-header {


### PR DESCRIPTION
## Summary
- Bold menu items in navigation and profile menus
- Align homepage tile text to the left and highlight upcoming events
- Ensure card titles display in bold across proposals and rehearsals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2323094008327843f9da6bcb90de2