### PR TITLE
fix: initialize Tailwind config before loading CDN

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,12 +13,14 @@
       gestion des prestations et paramètres utilisateurs (nom du groupe, mode sombre).
     -->
     <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            colors: {
-              pastel: {
-                50: '#fdf2f8'
+      window.tailwind = {
+        config: {
+          theme: {
+            extend: {
+              colors: {
+                pastel: {
+                  50: '#fdf2f8'
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary
- prevent `tailwind is not defined` by defining global config before loading CDN

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2356ea8488327a6171c777a09864b