### PR TITLE
feat: show message when no suggestions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -669,6 +669,13 @@
       container.appendChild(p);
       return;
     }
+    if (list.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'Aucune proposition pour l\u2019instant';
+      container.appendChild(empty);
+      return;
+    }
     // Afficher la liste
     list.forEach((item) => {
       const card = document.createElement('div');

--- a/public/style.css
+++ b/public/style.css
@@ -390,6 +390,15 @@ textarea {
   font-weight: bold;
 }
 
+/* Message affiché lorsqu'aucune donnée n'est disponible */
+.empty-state {
+  text-align: center;
+  color: var(--text-color);
+  opacity: 0.7;
+  font-style: italic;
+  margin-top: 12px;
+}
+
 /* Liste d'éléments sélectionnables */
 .select-list {
   max-height: 200px;


### PR DESCRIPTION
## Summary
- show empty-state message when no song suggestions are returned
- add CSS styling for the empty-state message

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a23bec600c83278a39d7d6acc5e44b