### PR TITLE
Affiche un état vide pour les répétitions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -989,6 +989,13 @@
       container.appendChild(p);
       return;
     }
+    if (list.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'Aucun morceau en répétition';
+      container.appendChild(empty);
+      return;
+    }
     list.forEach((song) => {
       const card = document.createElement('div');
       card.className = 'card collapsed bg-white rounded-lg shadow-md p-4 bg-blue-50';


### PR DESCRIPTION
## Summary
- Ajoute un contrôle après la récupération des répétitions pour afficher "Aucun morceau en répétition" lorsque la liste est vide
- Utilise la classe `empty-state` pour harmoniser l'apparence du message

## Testing
- `npm test` *(échoue : no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d026cd88327961c046ed38e179a