### PR TITLE
Fix missing add button when no rehearsals exist

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -994,8 +994,8 @@
       empty.className = 'empty-state';
       empty.textContent = 'Aucun morceau en répétition';
       container.appendChild(empty);
-      return;
     }
+
     list.forEach((song) => {
       const card = document.createElement('div');
       card.className = 'card collapsed bg-white rounded-lg shadow-md p-4 bg-blue-50';


### PR DESCRIPTION
## Summary
- Always render the "+" button for adding a rehearsal even if the list is empty

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a240029ea083279c67bdabeb9fd869