### PR TITLE
Ensure suggestion add button appears with empty list

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -674,7 +674,6 @@
       empty.className = 'empty-state';
       empty.textContent = 'Aucune proposition pour l\u2019instant';
       container.appendChild(empty);
-      return;
     }
     // Afficher la liste
     list.forEach((item) => {


### PR DESCRIPTION
## Summary
- Keep suggestion page active even when no items are listed
- Allow adding new suggestions when the list is empty by removing premature return

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a242677dd0832799a5ce9853ded05d