### PR TITLE
Style user info on settings page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2859,6 +2859,7 @@
     container.appendChild(header);
     if (currentUser) {
       const info = document.createElement('p');
+      info.className = 'user-info';
       info.textContent = `Utilisateur connecté: ${currentUser.username}`;
       container.appendChild(info);
     }

--- a/public/style.css
+++ b/public/style.css
@@ -671,3 +671,10 @@ textarea {
 .calendar-event.rehearsal {
   background: #6cf;
 }
+
+.user-info {
+  font-weight: bold;
+  text-align: center;
+  margin-top: 8px;
+  color: var(--primary-color);
+}


### PR DESCRIPTION
## Summary
- Highlight connected user's name in settings with `user-info` styling
- Add `.user-info` CSS class for centered, bold, and colored display

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python server.py` *(served updated assets, manually fetched /style.css)*

------
https://chatgpt.com/codex/tasks/task_e_68a574a5d9288327a44684f86ede1764