### PR TITLE
feat: update PWA icons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,8 @@
     -->
         <link rel="stylesheet" href="tailwind.css">
     <link rel="stylesheet" href="style.css">
-    <link rel="apple-touch-icon" href="Logobt-512.png">
+    <link rel="apple-touch-icon" sizes="220x220" href="logobt220.png">
+    <link rel="apple-touch-icon" sizes="512x512" href="Logobt-512.png">
     <link rel="manifest" href="manifest.json">
 </head>
 <body class="font-sans bg-pastel-50 text-slate-800">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,8 +7,8 @@
   "theme_color": "#222222",
   "icons": [
     {
-      "src": "Logobt.png",
-      "sizes": "192x192",
+      "src": "logobt220.png",
+      "sizes": "220x220",
       "type": "image/png"
       },
     {

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -6,6 +6,7 @@ const ASSETS = [
   '/style.css',
   '/app.js',
   '/Logobt.png',
+  '/logobt220.png',
   '/manifest.json',
   '/offline.html'
 ];


### PR DESCRIPTION
## Summary
- replace app icon with 220px version for manifest and apple touch icon
- cache new icon in service worker for offline use

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a62a3581b88327af12b247e71ed77e