### PR TITLE
Add password change endpoint and client UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2654,6 +2654,60 @@
     return section;
   }
 
+  function renderPasswordSection() {
+    const section = document.createElement('div');
+    section.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
+    const h3 = document.createElement('h3');
+    h3.textContent = 'Mot de passe';
+    section.appendChild(h3);
+    const form = document.createElement('form');
+    form.onsubmit = (e) => e.preventDefault();
+    const labelOld = document.createElement('label');
+    labelOld.textContent = 'Mot de passe actuel';
+    const inputOld = document.createElement('input');
+    inputOld.type = 'password';
+    inputOld.required = true;
+    inputOld.style.width = '100%';
+    const labelNew = document.createElement('label');
+    labelNew.textContent = 'Nouveau mot de passe';
+    const inputNew = document.createElement('input');
+    inputNew.type = 'password';
+    inputNew.required = true;
+    inputNew.style.width = '100%';
+    const submitBtn = document.createElement('button');
+    submitBtn.className = 'btn-primary';
+    submitBtn.type = 'submit';
+    submitBtn.textContent = 'Modifier';
+    submitBtn.style.marginTop = '8px';
+    const msg = document.createElement('p');
+    msg.style.marginTop = '8px';
+    form.appendChild(labelOld);
+    form.appendChild(inputOld);
+    form.appendChild(labelNew);
+    form.appendChild(inputNew);
+    form.appendChild(submitBtn);
+    form.appendChild(msg);
+    form.onsubmit = async (e) => {
+      e.preventDefault();
+      msg.textContent = '';
+      try {
+        await api('/password', 'PUT', {
+          oldPassword: inputOld.value,
+          newPassword: inputNew.value,
+        });
+        msg.style.color = 'green';
+        msg.textContent = 'Mot de passe mis à jour';
+        inputOld.value = '';
+        inputNew.value = '';
+      } catch (err) {
+        msg.style.color = 'var(--danger-color)';
+        msg.textContent = err.message;
+      }
+    };
+    section.appendChild(form);
+    return section;
+  }
+
   function renderThemeSection(currentSettings) {
     const section = document.createElement('div');
     section.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
@@ -2919,6 +2973,8 @@
     await refreshGroups();
     const themeSection = renderThemeSection(currentSettings);
     container.appendChild(themeSection);
+    const passwordSection = renderPasswordSection();
+    container.appendChild(passwordSection);
     const logoutSection = document.createElement('div');
     logoutSection.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
     const logoutBtn = document.createElement('button');

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -1,0 +1,55 @@
+import json
+from test_api import start_test_server, stop_test_server, request, extract_cookie
+
+
+def test_password_change(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / "test.db")
+    try:
+        # Register and login
+        status, headers, _ = request(
+            "POST", port, "/api/register", {"username": "alice", "password": "old"}
+        )
+        assert status == 200
+        status, headers, _ = request(
+            "POST", port, "/api/login", {"username": "alice", "password": "old"}
+        )
+        assert status == 200
+        cookie = extract_cookie(headers)
+        headers = {"Cookie": cookie}
+
+        # Change password
+        status, _, body = request(
+            "PUT",
+            port,
+            "/api/password",
+            {"oldPassword": "old", "newPassword": "new"},
+            headers,
+        )
+        assert status == 200
+        assert json.loads(body)["message"] == "Password updated"
+
+        # Old password should fail
+        status, _, _ = request(
+            "POST", port, "/api/login", {"username": "alice", "password": "old"}
+        )
+        assert status == 401
+
+        # New password should succeed
+        status, headers, _ = request(
+            "POST", port, "/api/login", {"username": "alice", "password": "new"}
+        )
+        assert status == 200
+
+        # Invalid current password when updating
+        cookie = extract_cookie(headers)
+        headers = {"Cookie": cookie}
+        status, _, _ = request(
+            "PUT",
+            port,
+            "/api/password",
+            {"oldPassword": "wrong", "newPassword": "x"},
+            headers,
+        )
+        assert status == 401
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- allow authenticated users to update their password via new `/api/password` endpoint
- expose a settings form in the frontend for changing the current password
- cover password change flow with automated tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a631960354832783a80cd2c5ee8ea0