### PR TITLE
Await suggestion re-render after vote

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -744,12 +744,16 @@
       likeBtn.textContent = '👍';
       likeBtn.onclick = async (e) => {
         e.stopPropagation();
+        likeBtn.disabled = true;
+        dislikeBtn.disabled = true;
         try {
           const updated = await api(`/suggestions/${item.id}/vote`, 'POST');
           likeCount.textContent = `❤️ ${updated.likes}`;
-          renderSuggestions(container);
+          await renderSuggestions(container);
         } catch (err) {
           alert(err.message);
+          likeBtn.disabled = false;
+          dislikeBtn.disabled = false;
         }
       };
 
@@ -758,12 +762,16 @@
       dislikeBtn.textContent = '👎';
       dislikeBtn.onclick = async (e) => {
         e.stopPropagation();
+        likeBtn.disabled = true;
+        dislikeBtn.disabled = true;
         try {
           const updated = await api(`/suggestions/${item.id}/vote`, 'DELETE');
           likeCount.textContent = `❤️ ${updated.likes}`;
-          renderSuggestions(container);
+          await renderSuggestions(container);
         } catch (err) {
           alert(err.message);
+          likeBtn.disabled = false;
+          dislikeBtn.disabled = false;
         }
       };
 


### PR DESCRIPTION
## Summary
- ensure voting buttons await suggestion rerender to prevent duplicate entries
- disable vote buttons while refreshing suggestions to block double clicks

## Testing
- ❌ `npm test` (no test specified)
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a77c21f9fc8327b9cfadc85eaf1262