### PR TITLE
Refresh groups after rename and cover UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2626,6 +2626,8 @@
         document.title = `${currentSettings.groupName} – BandTrack`;
         const groupNameEl = document.getElementById('group-name');
         if (groupNameEl) groupNameEl.textContent = currentSettings.groupName;
+        await refreshGroups(currentSettings.id || currentUser.groupId);
+        await renderSettings(document.getElementById('app'));
       } catch (err) {
         alert(err.message);
       }

--- a/tests/test_ui_group_rename.py
+++ b/tests/test_ui_group_rename.py
@@ -1,0 +1,41 @@
+from test_api import start_test_server, stop_test_server, request, extract_cookie
+from playwright.sync_api import sync_playwright
+
+
+def test_dropdown_updates_after_group_rename(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # Register, login and create a group via API
+        request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        cookie = extract_cookie(headers)
+        headers = {'Cookie': cookie}
+        status, _, _ = request('POST', port, '/api/groups', {'name': 'Band'}, headers)
+        assert status == 201
+
+        session_value = cookie.split('=', 1)[1]
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            context.add_cookies([
+                {
+                    'name': 'session_id',
+                    'value': session_value,
+                    'domain': '127.0.0.1',
+                    'path': '/',
+                }
+            ])
+            page = context.new_page()
+            page.goto(f'http://127.0.0.1:{port}/')
+            page.click('#hamburger')
+            page.click('#menu-settings')
+            page.wait_for_selector('#group-select option')
+            page.once('dialog', lambda dialog: dialog.accept('Renamed Band'))
+            page.click('#rename-group-btn')
+            page.wait_for_function("() => Array.from(document.querySelectorAll('#group-select option')).some(o => o.textContent === 'Renamed Band')")
+            options_text = page.eval_on_selector_all('#group-select option', 'els => els.map(e => e.textContent)')
+            assert 'Renamed Band' in options_text
+            context.close()
+            browser.close()
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- Refresh group list and re-render settings after renaming a group
- Add UI test to ensure rename updates dropdown

## Testing
- `pytest tests/test_settings.py::test_group_rename -q`
- `pytest tests/test_ui_group_rename.py::test_dropdown_updates_after_group_rename -q` *(fails: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68aadcbc0308832780272d85c8f88977