### PR TITLE
Add group rename API endpoint and tests

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2620,13 +2620,15 @@
     renameBtn.onclick = async () => {
       const newName = prompt('Nouveau nom du groupe', currentSettings.groupName);
       if (!newName || newName.trim() === '' || newName === currentSettings.groupName) return;
-      currentSettings.groupName = newName.trim();
+      const trimmed = newName.trim();
+      const gid = currentSettings.id || currentUser.groupId;
       try {
-        await api('/settings', 'PUT', currentSettings);
+        await api(`/groups/${gid}`, 'PUT', { name: trimmed });
+        currentSettings.groupName = trimmed;
         document.title = `${currentSettings.groupName} – BandTrack`;
         const groupNameEl = document.getElementById('group-name');
         if (groupNameEl) groupNameEl.textContent = currentSettings.groupName;
-        await refreshGroups(currentSettings.id || currentUser.groupId);
+        await refreshGroups(gid);
         await renderSettings(document.getElementById('app'));
       } catch (err) {
         alert(err.message);

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -58,7 +58,7 @@ def test_settings_update(tmp_path):
         group_id = json.loads(body)['id']
 
         status, _, _ = request('PUT', port, f'/api/{group_id}/settings', {
-            'groupName': 'New Band',
+            'groupName': 'Band2',
             'darkMode': True,
             'template': 'modern'
         }, headers)
@@ -67,14 +67,14 @@ def test_settings_update(tmp_path):
         status, _, body = request('GET', port, f'/api/{group_id}/settings', headers=headers)
         assert status == 200
         data = json.loads(body)
-        assert data['groupName'] == 'New Band'
+        assert data['groupName'] == 'Band2'
         assert data['darkMode'] is True
         assert data['template'] == 'modern'
 
         status, _, body = request('GET', port, '/api/groups', headers=headers)
         assert status == 200
         groups = json.loads(body)
-        assert any(g['id'] == group_id and g['name'] == 'New Band' for g in groups)
+        assert any(g['id'] == group_id and g['name'] == 'Band2' for g in groups)
     finally:
         stop_test_server(httpd, thread)
 
@@ -91,9 +91,8 @@ def test_group_rename(tmp_path):
         assert status == 201
         group_id = json.loads(body)['id']
 
-        status, _, _ = request('PUT', port, f'/api/{group_id}/settings', {
-            'groupName': 'Renamed Band',
-            'darkMode': False
+        status, _, _ = request('PUT', port, f'/api/groups/{group_id}', {
+            'name': 'Renamed Band'
         }, headers)
         assert status == 200
 
@@ -101,5 +100,37 @@ def test_group_rename(tmp_path):
         assert status == 200
         groups = json.loads(body)
         assert any(g['id'] == group_id and g['name'] == 'Renamed Band' for g in groups)
+    finally:
+        stop_test_server(httpd, thread)
+
+
+def test_group_rename_unauthorized(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        cookie_alice = extract_cookie(headers)
+        headers_alice = {'Cookie': cookie_alice}
+
+        status, _, body = request('POST', port, '/api/groups', {'name': 'Band2'}, headers_alice)
+        assert status == 201
+        data = json.loads(body)
+        group_id = data['id']
+        code = data['invitationCode']
+
+        request('POST', port, '/api/register', {'username': 'bob', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'bob', 'password': 'pw'})
+        cookie_bob = extract_cookie(headers)
+        headers_bob = {'Cookie': cookie_bob}
+        status, _, _ = request('POST', port, '/api/groups/join', {'code': code}, headers_bob)
+        assert status == 201
+
+        status, _, _ = request('PUT', port, f'/api/groups/{group_id}', {'name': 'Hacked'}, headers_bob)
+        assert status == 403
+
+        status, _, body = request('GET', port, '/api/groups', headers=headers_alice)
+        assert status == 200
+        groups = json.loads(body)
+        assert any(g['id'] == group_id and g['name'] == 'Band2' for g in groups)
     finally:
         stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- add `api_update_group` for PUT `/api/groups/<group_id>` requiring admin role
- refactor frontend group rename to call new endpoint
- cover group rename authorization and success in tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*
- `pytest --ignore=tests/test_ui_group_rename.py`


------
https://chatgpt.com/codex/tasks/task_e_68aade33d4c8832781b1ff4dc0e52959