### PR TITLE
feat(settings): display group members

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2780,6 +2780,47 @@
     return section;
   }
 
+  async function renderMembersSection() {
+    const section = document.createElement('div');
+    section.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
+    const h3 = document.createElement('h3');
+    h3.textContent = 'Membres';
+    section.appendChild(h3);
+    if (activeGroupId == null || currentUser?.needsGroup) {
+      const p = document.createElement('p');
+      p.textContent = 'Aucun groupe actif';
+      section.appendChild(p);
+      return section;
+    }
+    try {
+      const members = await api(`/groups/${activeGroupId}/members`);
+      const table = document.createElement('table');
+      table.className = 'user-table';
+      const thead = document.createElement('thead');
+      thead.innerHTML = '<tr><th>Membre</th><th>Rôle</th></tr>';
+      table.appendChild(thead);
+      const tbody = document.createElement('tbody');
+      members.forEach((m) => {
+        const tr = document.createElement('tr');
+        const nameTd = document.createElement('td');
+        nameTd.textContent = m.username;
+        const roleTd = document.createElement('td');
+        roleTd.textContent = m.role;
+        tr.appendChild(nameTd);
+        tr.appendChild(roleTd);
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      section.appendChild(table);
+    } catch (err) {
+      const p = document.createElement('p');
+      p.style.color = 'var(--danger-color)';
+      p.textContent = 'Impossible de récupérer les membres du groupe';
+      section.appendChild(p);
+    }
+    return section;
+  }
+
   async function renderAdminSection(container) {
     const section = document.createElement('div');
     section.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
@@ -2983,6 +3024,8 @@
     const groupSection = renderGroupSection(currentSettings);
     container.appendChild(groupSection);
     await refreshGroups();
+    const membersSection = await renderMembersSection();
+    container.appendChild(membersSection);
     const themeSection = renderThemeSection(currentSettings);
     container.appendChild(themeSection);
     const passwordSection = renderPasswordSection();


### PR DESCRIPTION
## Summary
- add read-only members list to settings
- include members section after group selection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeba86cb483279709d093d4dc6b66