### PR TITLE
feat: add email-based group invitations

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2949,6 +2949,29 @@
         addDiv.appendChild(addBtn);
         section.appendChild(addDiv);
       }
+      const inviteDiv = document.createElement('div');
+      const emailInput = document.createElement('input');
+      emailInput.type = 'email';
+      emailInput.placeholder = 'adresse e-mail';
+      inviteDiv.appendChild(emailInput);
+      const inviteBtn = document.createElement('button');
+      inviteBtn.textContent = 'Inviter';
+      inviteBtn.style.marginLeft = '8px';
+      inviteBtn.onclick = async () => {
+        const email = emailInput.value.trim();
+        if (!email) return;
+        try {
+          const res = await api(`/groups/${activeGroupId}/invite`, 'POST', { email });
+          if (res.temporaryPassword) {
+            alert(`Mot de passe temporaire : ${res.temporaryPassword}`);
+          }
+          renderSettings(container);
+        } catch (err) {
+          alert(err.message);
+        }
+      };
+      inviteDiv.appendChild(inviteBtn);
+      section.appendChild(inviteDiv);
       const adminHeader = document.createElement('h4');
       adminHeader.textContent = 'Gestion des utilisateurs';
       adminHeader.style.marginTop = '30px';

--- a/server.py
+++ b/server.py
@@ -1107,6 +1107,12 @@ class BandTrackHandler(BaseHTTPRequestHandler):
                         return send_json(self, HTTPStatus.BAD_REQUEST, {'error': 'Invalid group id'})
                     if method == 'PUT':
                         return self.api_update_group(gid, body, user)
+                if len(parts) >= 5 and parts[4] == 'invite' and method == 'POST':
+                    try:
+                        gid = int(parts[3])
+                    except ValueError:
+                        return send_json(self, HTTPStatus.BAD_REQUEST, {'error': 'Invalid group id'})
+                    return self.api_group_invite(gid, body, user)
                 if len(parts) >= 5 and parts[4] == 'members':
                     try:
                         gid = int(parts[3])
@@ -1741,6 +1747,67 @@ class BandTrackHandler(BaseHTTPRequestHandler):
                 send_json(self, HTTPStatus.NOT_FOUND, {'error': 'Membership not found'})
             return
         raise NotImplementedError
+
+    def api_group_invite(self, group_id: int, body: dict, user: dict):
+        """Invite a user to the group by email. If the email does not
+        correspond to an existing user, create a provisional account with a
+        temporary password."""
+        role = verify_group_access(user['id'], group_id, 'admin')
+        if role != 'admin':
+            send_json(self, HTTPStatus.FORBIDDEN, {'error': 'Forbidden'})
+            return
+        email = (body.get('email') or '').strip().lower()
+        if not email or '@' not in email:
+            send_json(self, HTTPStatus.BAD_REQUEST, {'error': 'Invalid email'})
+            return
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute('SELECT id, username FROM users WHERE LOWER(username) = LOWER(?)', (email,))
+        row = cur.fetchone()
+        if row:
+            user_id = row['id']
+            username = row['username']
+            conn.close()
+            if get_membership(user_id, group_id):
+                send_json(self, HTTPStatus.CONFLICT, {'error': 'Membership already exists'})
+                return
+            create_membership(user_id, group_id, 'user', None)
+            membership = get_membership(user_id, group_id)
+            send_json(self, HTTPStatus.CREATED, {
+                'id': membership['id'],
+                'userId': membership['user_id'],
+                'username': username,
+                'role': membership['role'],
+                'nickname': membership['nickname'],
+                'joinedAt': membership['joined_at'],
+                'active': bool(membership['active']),
+            })
+            return
+        # Create provisional user
+        temp_password = ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(12))
+        salt, pwd_hash = hash_password(temp_password)
+        cur.execute(
+            'INSERT INTO users (username, salt, password_hash, role, last_group_id) VALUES (?, ?, ?, ?, ?)',
+            (email, salt, pwd_hash, 'user', group_id),
+        )
+        user_id = cur.lastrowid
+        cur.execute(
+            'INSERT INTO memberships (user_id, group_id, role, nickname, active) VALUES (?, ?, ?, ?, 1)',
+            (user_id, group_id, 'user', None),
+        )
+        conn.commit()
+        conn.close()
+        membership = get_membership(user_id, group_id)
+        send_json(self, HTTPStatus.CREATED, {
+            'id': membership['id'],
+            'userId': membership['user_id'],
+            'username': email,
+            'role': membership['role'],
+            'nickname': membership['nickname'],
+            'joinedAt': membership['joined_at'],
+            'active': bool(membership['active']),
+            'temporaryPassword': temp_password,
+        })
 
     def api_get_suggestions(self, user: dict):
         role = verify_group_access(user['id'], user['group_id'])

--- a/tests/test_group_invite.py
+++ b/tests/test_group_invite.py
@@ -1,0 +1,52 @@
+import json
+from test_api import start_test_server, stop_test_server, request, extract_cookie
+
+
+def test_group_invite_new_user(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # Register admin user
+        request('POST', port, '/api/register', {'username': 'admin@example.com', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'admin@example.com', 'password': 'pw'})
+        cookie_admin = extract_cookie(headers)
+        headers_admin = {'Cookie': cookie_admin}
+
+        # Invite new user by email
+        status, _, body = request('POST', port, '/api/groups/1/invite', {'email': 'newbie@example.com'}, headers_admin)
+        assert status == 201
+        data = json.loads(body)
+        assert data['username'] == 'newbie@example.com'
+        assert 'temporaryPassword' in data
+        temp_pw = data['temporaryPassword']
+
+        # New user can login with temporary password
+        status, _, _ = request('POST', port, '/api/login', {'username': 'newbie@example.com', 'password': temp_pw})
+        assert status == 200
+    finally:
+        stop_test_server(httpd, thread)
+
+
+def test_group_invite_existing_user(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # Register admin user
+        request('POST', port, '/api/register', {'username': 'admin@example.com', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'admin@example.com', 'password': 'pw'})
+        cookie_admin = extract_cookie(headers)
+        headers_admin = {'Cookie': cookie_admin}
+
+        # Register another user and remove from group
+        request('POST', port, '/api/register', {'username': 'bob@example.com', 'password': 'pw'})
+        status, _, body = request('GET', port, '/api/groups/1/members', headers=headers_admin)
+        members = json.loads(body)
+        bob_member = next(m for m in members if m['username'] == 'bob@example.com')
+        request('DELETE', port, '/api/groups/1/members', {'id': bob_member['id']}, headers_admin)
+
+        # Invite existing user back by email
+        status, _, body = request('POST', port, '/api/groups/1/invite', {'email': 'bob@example.com'}, headers_admin)
+        assert status == 201
+        data = json.loads(body)
+        assert data['username'] == 'bob@example.com'
+        assert 'temporaryPassword' not in data
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- add `/groups/<id>/invite` endpoint to invite users by email
- provision accounts for new addresses and return temporary password
- allow admins to invite by email from settings page
- cover invitation flow with tests

## Testing
- `pytest tests/test_group_invite.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68aaf8134d008327996090dd80bfb55f