### PR TITLE
Add account deletion option in settings

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -207,6 +207,16 @@
     }
   }
 
+  async function handleDeleteAccount() {
+    try {
+      await api('/me', 'DELETE');
+      currentUser = null;
+      renderApp();
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
   async function changeGroup(id) {
     await api('/context', 'PUT', { groupId: Number(id) });
     localStorage.setItem('activeGroupId', String(id));
@@ -3082,6 +3092,12 @@
     logoutBtn.textContent = 'Se déconnecter';
     logoutBtn.onclick = handleLogout;
     logoutSection.appendChild(logoutBtn);
+    const deleteBtn = document.createElement('button');
+    deleteBtn.id = 'delete-account-btn';
+    deleteBtn.className = 'delete-account-btn';
+    deleteBtn.textContent = 'Supprimer mon compte';
+    deleteBtn.onclick = handleDeleteAccount;
+    logoutSection.appendChild(deleteBtn);
     container.appendChild(logoutSection);
     if (isAdmin()) {
       const adminSection = await renderAdminSection(container);

--- a/public/style.css
+++ b/public/style.css
@@ -552,7 +552,8 @@ textarea {
 }
 
 /* Bouton de déconnexion */
-.logout-btn {
+.logout-btn,
+.delete-account-btn {
   margin-top: 20px;
   padding: 10px;
   background-color: var(--danger-color);
@@ -563,7 +564,8 @@ textarea {
   width: 100%;
 }
 
-.logout-btn:hover {
+.logout-btn:hover,
+.delete-account-btn:hover {
   opacity: 0.9;
 }
 

--- a/tests/test_ui_account_deletion.py
+++ b/tests/test_ui_account_deletion.py
@@ -1,0 +1,36 @@
+from test_api import start_test_server, stop_test_server, request, extract_cookie
+from playwright.sync_api import sync_playwright
+
+
+def test_ui_account_deletion(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # Register and login to create session
+        request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        assert status == 200
+        cookie = extract_cookie(headers)
+        session_value = cookie.split('=', 1)[1]
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            context.add_cookies([
+                {
+                    'name': 'session_id',
+                    'value': session_value,
+                    'domain': '127.0.0.1',
+                    'path': '/',
+                }
+            ])
+            page = context.new_page()
+            page.goto(f'http://127.0.0.1:{port}/')
+            page.click('#hamburger')
+            page.click('#menu-settings')
+            page.click('#delete-account-btn')
+            page.wait_for_selector('text=Se connecter')
+            context.close()
+            browser.close()
+        status, _, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        assert status == 401
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- Allow users to remove their account via settings with API `/me` DELETE
- Style new account deletion button
- Add Playwright test ensuring account deletion prevents re-login

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68ab192162b0832795af1d33a08e1c7f