### PR TITLE
Fix membership management API parameters and self-action checks

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2902,10 +2902,10 @@
           if (m.role === r) opt.selected = true;
           sel.appendChild(opt);
         });
-        if (m.id === currentUser.id) sel.disabled = true;
+        if (m.userId === currentUser.id) sel.disabled = true;
         sel.onchange = async () => {
           try {
-            await api(`/groups/${activeGroupId}/members`, 'PUT', { userId: m.id, role: sel.value });
+            await api(`/groups/${activeGroupId}/members`, 'PUT', { id: m.id, role: sel.value });
           } catch (err) {
             alert(err.message);
           }
@@ -2914,11 +2914,11 @@
         const actionsTd = document.createElement('td');
         const removeBtn = document.createElement('button');
         removeBtn.textContent = 'Retirer';
-        removeBtn.disabled = m.id === currentUser.id;
+        removeBtn.disabled = m.userId === currentUser.id;
         removeBtn.onclick = async () => {
           if (!confirm('Supprimer ce membre ?')) return;
           try {
-            await api(`/groups/${activeGroupId}/members`, 'DELETE', { userId: m.id });
+            await api(`/groups/${activeGroupId}/members`, 'DELETE', { id: m.id });
             tr.remove();
           } catch (err) {
             alert(err.message);


### PR DESCRIPTION
## Summary
- Use membership `id` instead of `userId` in member update and deletion API calls
- Disable role and delete actions for the current user by comparing `m.userId`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1b4a9cbc83278a1bfeea16edc81c