### PR TITLE
feat: allow deleting account from group setup

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -424,6 +424,12 @@
     joinBtn.onclick = () => showJoinGroupDialog();
     btnRow.appendChild(joinBtn);
     container.appendChild(btnRow);
+    const deleteBtn = document.createElement('button');
+    deleteBtn.id = 'delete-account-btn';
+    deleteBtn.className = 'delete-account-btn';
+    deleteBtn.textContent = 'Supprimer mon compte';
+    deleteBtn.onclick = handleDeleteAccount;
+    container.appendChild(deleteBtn);
     app.appendChild(container);
   }
 

--- a/tests/test_ui_account_deletion.py
+++ b/tests/test_ui_account_deletion.py
@@ -34,3 +34,35 @@ def test_ui_account_deletion(tmp_path):
         assert status == 401
     finally:
         stop_test_server(httpd, thread)
+
+
+def test_ui_account_deletion_from_group_setup(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        request('POST', port, '/api/register', {'username': 'bob', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'bob', 'password': 'pw'})
+        assert status == 200
+        cookie = extract_cookie(headers)
+        session_value = cookie.split('=', 1)[1]
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            context.add_cookies([
+                {
+                    'name': 'session_id',
+                    'value': session_value,
+                    'domain': '127.0.0.1',
+                    'path': '/',
+                }
+            ])
+            page = context.new_page()
+            page.goto(f'http://127.0.0.1:{port}/')
+            page.wait_for_selector('#delete-account-btn')
+            page.click('#delete-account-btn')
+            page.wait_for_selector('text=Se connecter')
+            context.close()
+            browser.close()
+        status, _, _ = request('POST', port, '/api/login', {'username': 'bob', 'password': 'pw'})
+        assert status == 401
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- add delete account button on group setup screen
- wire group setup delete button to existing handler
- add UI test ensuring account can be removed from group setup

## Testing
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*
- `pytest tests/test_ui_account_deletion.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2b44e51c83279b469c7d2270da66