### PR TITLE
Ensure membership deletion respects group boundaries

### DIFF
--- a/server.py
+++ b/server.py
@@ -941,11 +941,14 @@ def update_membership(membership_id: int, role: str, nickname: str | None, activ
     return changes
 
 
-def delete_membership(membership_id: int) -> int:
-    """Delete a membership by its ID."""
+def delete_membership(membership_id: int, group_id: int) -> int:
+    """Delete a membership by its ID and group."""
     conn = get_db_connection()
     cur = conn.cursor()
-    cur.execute('DELETE FROM memberships WHERE id = ?', (membership_id,))
+    cur.execute(
+        'DELETE FROM memberships WHERE id = ? AND group_id = ?',
+        (membership_id, group_id),
+    )
     conn.commit()
     changes = cur.rowcount
     conn.close()
@@ -1792,7 +1795,7 @@ class BandTrackHandler(BaseHTTPRequestHandler):
                 except (TypeError, ValueError):
                     send_json(self, HTTPStatus.BAD_REQUEST, {'error': 'Invalid membership id'})
                     return
-            deleted = delete_membership(membership_id)
+            deleted = delete_membership(membership_id, group_id)
             if deleted:
                 send_json(self, HTTPStatus.OK, {'message': 'Member deleted'})
             else:

--- a/tests/test_group_members.py
+++ b/tests/test_group_members.py
@@ -84,3 +84,41 @@ def test_group_members_add(tmp_path):
         assert any(m['username'] == 'bob' for m in members)
     finally:
         stop_test_server(httpd, thread)
+
+
+def test_group_members_cross_group_delete(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # Register admin user and log in
+        request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        cookie_admin = extract_cookie(headers)
+        headers_admin = {'Cookie': cookie_admin}
+
+        # Register bob and get his user id
+        request('POST', port, '/api/register', {'username': 'bob', 'password': 'pw'})
+        status, _, body = request('GET', port, '/api/groups/1/members', headers=headers_admin)
+        members = json.loads(body)
+        bob_member = next(m for m in members if m['username'] == 'bob')
+        bob_user_id = bob_member['userId']
+
+        # Create second group and add bob to it
+        status, _, body = request('POST', port, '/api/groups', {'name': 'Band2'}, headers=headers_admin)
+        group2_id = json.loads(body)['id']
+        request('POST', port, f'/api/groups/{group2_id}/members', {'userId': bob_user_id}, headers=headers_admin)
+
+        # Get bob's membership id in group2
+        status, _, body = request('GET', port, f'/api/groups/{group2_id}/members', headers=headers_admin)
+        bob_member_group2 = next(m for m in json.loads(body) if m['username'] == 'bob')
+        member2_id = bob_member_group2['id']
+
+        # Attempt to delete group2 membership via group1 endpoint
+        status, _, _ = request('DELETE', port, '/api/groups/1/members', {'id': member2_id}, headers=headers_admin)
+        assert status == 404
+
+        # Ensure bob's membership in group2 still exists
+        status, _, body = request('GET', port, f'/api/groups/{group2_id}/members', headers=headers_admin)
+        members = json.loads(body)
+        assert any(m['id'] == member2_id for m in members)
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- Require `group_id` when deleting memberships to enforce group scoping
- Pass `group_id` from `api_group_members` to the deletion helper
- Add regression test blocking cross-group membership deletions

## Testing
- `pytest tests/test_group_members.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab41d5b1708327afcd5f1aba1b9987