### PR TITLE
Add confirmation for account deletion

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -208,6 +208,8 @@
   }
 
   async function handleDeleteAccount() {
+    const confirmed = confirm('Êtes-vous sûr de vouloir supprimer votre compte ?');
+    if (!confirmed) return;
     try {
       await api('/me', 'DELETE');
       currentUser = null;

--- a/tests/test_ui_account_deletion.py
+++ b/tests/test_ui_account_deletion.py
@@ -26,6 +26,12 @@ def test_ui_account_deletion(tmp_path):
             page.goto(f'http://127.0.0.1:{port}/')
             page.click('#hamburger')
             page.click('#menu-settings')
+            def handle_dialog(dialog):
+                assert dialog.type == 'confirm'
+                assert dialog.message == 'Êtes-vous sûr de vouloir supprimer votre compte ?'
+                dialog.accept()
+
+            page.once('dialog', handle_dialog)
             page.click('#delete-account-btn')
             page.wait_for_selector('text=Se connecter')
             context.close()
@@ -58,6 +64,12 @@ def test_ui_account_deletion_from_group_setup(tmp_path):
             page = context.new_page()
             page.goto(f'http://127.0.0.1:{port}/')
             page.wait_for_selector('#delete-account-btn')
+            def handle_dialog(dialog):
+                assert dialog.type == 'confirm'
+                assert dialog.message == 'Êtes-vous sûr de vouloir supprimer votre compte ?'
+                dialog.accept()
+
+            page.once('dialog', handle_dialog)
             page.click('#delete-account-btn')
             page.wait_for_selector('text=Se connecter')
             context.close()


### PR DESCRIPTION
## Summary
- Ask for confirmation before deleting account and only proceed on acceptance
- Update UI tests to acknowledge the confirmation dialog

## Testing
- `pytest tests/test_ui_account_deletion.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68ab48d60cb083278d5a7f9ec98a4455