### PR TITLE
Add test to prevent account deletion while owning group

### DIFF
--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -1,3 +1,4 @@
+import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
@@ -20,5 +21,30 @@ def test_account_deletion(tmp_path):
         # Login should fail after deletion
         status, _, _ = request('POST', port, '/api/login', {'username': 'bob', 'password': 'pw'})
         assert status == 401
+    finally:
+        stop_test_server(httpd, thread)
+
+
+def test_cannot_delete_account_while_owning_group(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # Register initial admin user to set up default group
+        request('POST', port, '/api/register', {'username': 'admin', 'password': 'pw'})
+
+        # Register a user who will own a group
+        status, headers, _ = request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        assert status == 200
+        cookie = extract_cookie(headers)
+        headers = {'Cookie': cookie}
+
+        # Create a group
+        status, _, _ = request('POST', port, '/api/groups', {'name': 'Band'}, headers)
+        assert status == 201
+
+        # Attempt to delete the account
+        status, _, body = request('DELETE', port, '/api/me', headers=headers)
+        assert status == 400
+        data = json.loads(body)
+        assert data['error'] == 'Cannot delete account while owning a group'
     finally:
         stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- add test ensuring account deletion fails if user owns a group

## Testing
- `pytest tests/test_account_deletion.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4952ecc48327ac580fde7aa101c8