### PR TITLE
Ensure settings delete account button is always visible

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3116,15 +3116,6 @@
       return;
     }
     const currentSettings = { ...settings };
-    const groupSection = renderGroupSection(currentSettings);
-    container.appendChild(groupSection);
-    await refreshGroups();
-    const membersSection = await renderMembersSection();
-    container.appendChild(membersSection);
-    const themeSection = renderThemeSection(currentSettings);
-    container.appendChild(themeSection);
-    const passwordSection = renderPasswordSection();
-    container.appendChild(passwordSection);
     const logoutSection = document.createElement('div');
     logoutSection.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
     const logoutBtn = document.createElement('button');
@@ -3138,6 +3129,19 @@
     deleteBtn.textContent = 'Supprimer mon compte';
     deleteBtn.onclick = handleDeleteAccount;
     logoutSection.appendChild(deleteBtn);
+    const groupSection = renderGroupSection(currentSettings);
+    container.appendChild(groupSection);
+    try {
+      await refreshGroups();
+      const membersSection = await renderMembersSection();
+      container.appendChild(membersSection);
+    } catch (err) {
+      console.error('Failed to load groups or members', err);
+    }
+    const themeSection = renderThemeSection(currentSettings);
+    container.appendChild(themeSection);
+    const passwordSection = renderPasswordSection();
+    container.appendChild(passwordSection);
     container.appendChild(logoutSection);
     if (isAdmin()) {
       const adminSection = await renderAdminSection(container);

--- a/tests/test_ui_delete_account_button_visible.py
+++ b/tests/test_ui_delete_account_button_visible.py
@@ -1,0 +1,34 @@
+from test_api import start_test_server, stop_test_server, request, extract_cookie
+from playwright.sync_api import sync_playwright
+
+
+def test_delete_account_button_visible(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        # register and login to obtain session cookie
+        request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        assert status == 200
+        cookie = extract_cookie(headers)
+        session_value = cookie.split('=', 1)[1]
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            context = browser.new_context()
+            context.add_cookies([
+                {
+                    'name': 'session_id',
+                    'value': session_value,
+                    'domain': '127.0.0.1',
+                    'path': '/',
+                }
+            ])
+            page = context.new_page()
+            page.goto(f'http://127.0.0.1:{port}/')
+            page.click('#hamburger')
+            page.click('#menu-settings')
+            page.wait_for_selector('#delete-account-btn')
+            assert page.is_visible('#delete-account-btn')
+            context.close()
+            browser.close()
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- Always build delete account section before async group/member fetch so the button renders even on failure
- Add Playwright test asserting the delete account button is visible in settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68ab509519088327a2e9359eb76ef232