### PR TITLE
Allow members to leave groups themselves

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2921,10 +2921,10 @@
         roleTd.appendChild(sel);
         const actionsTd = document.createElement('td');
         const removeBtn = document.createElement('button');
-        removeBtn.textContent = 'Retirer';
-        removeBtn.disabled = m.userId === currentUser.id;
+        removeBtn.textContent = m.userId === currentUser.id ? 'Quitter' : 'Retirer';
         removeBtn.onclick = async () => {
-          if (!confirm('Supprimer ce membre ?')) return;
+          const confirmMsg = m.userId === currentUser.id ? 'Quitter le groupe ?' : 'Supprimer ce membre ?';
+          if (!confirm(confirmMsg)) return;
           try {
             const res = await fetch(`/api/groups/${activeGroupId}/members`, {
               method: 'DELETE',
@@ -2956,6 +2956,11 @@
             if (!res.ok) {
               console.error('Remove member failed:', json);
               alert(json?.error || 'Erreur API');
+              return;
+            }
+            if (m.userId === currentUser.id) {
+              currentUser.needsGroup = true;
+              renderApp();
               return;
             }
             tr.remove();


### PR DESCRIPTION
## Summary
- Let current users remove themselves from group with "Quitter" button
- Add confirmation message when leaving a group
- Refresh app and mark user as needing group after leaving

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ab55cb6b6c83278d6275d3d527c1fd