### PR TITLE
Ensure delete account button visible and unique

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -427,7 +427,7 @@
     btnRow.appendChild(joinBtn);
     container.appendChild(btnRow);
     const deleteBtn = document.createElement('button');
-    deleteBtn.id = 'delete-account-btn';
+    deleteBtn.id = 'delete-account-btn-group-setup';
     deleteBtn.className = 'delete-account-btn';
     deleteBtn.textContent = 'Supprimer mon compte';
     deleteBtn.onclick = handleDeleteAccount;
@@ -3110,17 +3110,6 @@
       info.textContent = `Utilisateur connecté: ${currentUser.username}`;
       container.appendChild(info);
     }
-    let settings;
-    try {
-      settings = await api('/settings');
-    } catch (err) {
-      const p = document.createElement('p');
-      p.style.color = 'var(--danger-color)';
-      p.textContent = 'Impossible de récupérer les paramètres';
-      container.appendChild(p);
-      return;
-    }
-    const currentSettings = { ...settings };
     const logoutSection = document.createElement('div');
     logoutSection.className = 'settings-section bg-white rounded-lg shadow-md p-4 bg-purple-50';
     const logoutBtn = document.createElement('button');
@@ -3134,6 +3123,18 @@
     deleteBtn.textContent = 'Supprimer mon compte';
     deleteBtn.onclick = handleDeleteAccount;
     logoutSection.appendChild(deleteBtn);
+    let settings;
+    try {
+      settings = await api('/settings');
+    } catch (err) {
+      const p = document.createElement('p');
+      p.style.color = 'var(--danger-color)';
+      p.textContent = 'Impossible de récupérer les paramètres';
+      container.appendChild(p);
+      container.appendChild(logoutSection);
+      return;
+    }
+    const currentSettings = { ...settings };
     const groupSection = renderGroupSection(currentSettings);
     container.appendChild(groupSection);
     try {

--- a/tests/test_ui_account_deletion.py
+++ b/tests/test_ui_account_deletion.py
@@ -63,14 +63,14 @@ def test_ui_account_deletion_from_group_setup(tmp_path):
             ])
             page = context.new_page()
             page.goto(f'http://127.0.0.1:{port}/')
-            page.wait_for_selector('#delete-account-btn')
+            page.wait_for_selector('#delete-account-btn-group-setup')
             def handle_dialog(dialog):
                 assert dialog.type == 'confirm'
                 assert dialog.message == 'Êtes-vous sûr de vouloir supprimer votre compte ?'
                 dialog.accept()
 
             page.once('dialog', handle_dialog)
-            page.click('#delete-account-btn')
+            page.click('#delete-account-btn-group-setup')
             page.wait_for_selector('text=Se connecter')
             context.close()
             browser.close()

--- a/tests/test_ui_delete_account_button_visible.py
+++ b/tests/test_ui_delete_account_button_visible.py
@@ -10,6 +10,9 @@ def test_delete_account_button_visible(tmp_path):
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
         assert status == 200
         cookie = extract_cookie(headers)
+        headers = {'Cookie': cookie}
+        status, _, _ = request('POST', port, '/api/groups', {'name': 'Band'}, headers)
+        assert status == 201
         session_value = cookie.split('=', 1)[1]
         with sync_playwright() as p:
             browser = p.chromium.launch()
@@ -26,6 +29,7 @@ def test_delete_account_button_visible(tmp_path):
             page.goto(f'http://127.0.0.1:{port}/')
             page.click('#hamburger')
             page.click('#menu-settings')
+            page.wait_for_load_state('networkidle')
             page.wait_for_selector('#delete-account-btn')
             assert page.is_visible('#delete-account-btn')
             context.close()


### PR DESCRIPTION
## Summary
- Always render the delete account button within settings and remove duplicate IDs
- Add Playwright test ensuring button visibility for a standard user
- Adjust account deletion test for updated button ID

## Testing
- `pytest tests/test_ui_delete_account_button_visible.py tests/test_ui_account_deletion.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69690da0832780524beafc82e77f