### PR TITLE
Require member identifier for group member deletion

### DIFF
--- a/server.py
+++ b/server.py
@@ -1777,13 +1777,10 @@ class BandTrackHandler(BaseHTTPRequestHandler):
             membership_id = None
             target_user_id = None
             if body.get('id') is None and body.get('userId') is None:
-                target_user_id = user['id']
-                membership = get_membership(target_user_id, group_id)
-                if not membership:
-                    send_json(self, HTTPStatus.NOT_FOUND, {'error': 'Membership not found'})
-                    return
-                membership_id = membership['id']
-            elif body.get('id') is None and body.get('userId') is not None:
+                log_event(user['id'], 'delete_member_failed', {'groupId': group_id, 'reason': 'missing member identifier'})
+                send_json(self, HTTPStatus.BAD_REQUEST, {'error': 'Missing member identifier'})
+                return
+            if body.get('id') is None:
                 try:
                     target_user_id = int(body.get('userId'))
                 except (TypeError, ValueError):

--- a/tests/test_group_members.py
+++ b/tests/test_group_members.py
@@ -122,3 +122,17 @@ def test_group_members_cross_group_delete(tmp_path):
         assert any(m['id'] == member2_id for m in members)
     finally:
         stop_test_server(httpd, thread)
+
+
+def test_group_members_delete_requires_identifier(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+    try:
+        request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
+        status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
+        cookie_admin = extract_cookie(headers)
+        headers_admin = {'Cookie': cookie_admin}
+        status, _, body = request('DELETE', port, '/api/groups/1/members', {}, headers_admin)
+        assert status == 400
+        assert json.loads(body)['error'] == 'Missing member identifier'
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- ensure group member deletion requires explicit `id` or `userId`
- log and return 400 when member identifier missing
- cover missing identifier case in group member tests

## Testing
- `pytest tests/test_group_members.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab70a067e4832799420d36561ea59d